### PR TITLE
feat(ilingo)!: pluralization, fallback chain, missing-key handler

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -5,24 +5,41 @@
 ilingo follows a small **port-and-adapter** design:
 
 - **Port**: `IStore` (`packages/ilingo/src/store/types.ts`) defines `get`, `set`, `getLocales`.
-- **Adapters**: `MemoryStore` (default, in-memory) and `FSStore` (lazy-loads files from disk) implement the port.
-- **Orchestrator**: `Ilingo` (`packages/ilingo/src/module.ts`) holds a `Set<IStore>`, iterates through stores on each `get()` until one returns a hit, then applies the `{{var}}` template formatter.
+- **Adapters**: `MemoryStore` (default, in-memory) and `FSStore` (lazy-loads files from disk, persists `set()` to JSON) implement the port.
+- **Orchestrator**: `Ilingo` (`packages/ilingo/src/module.ts`) holds a `Set<IStore>` plus per-instance state for the locale, fallback chain, missing-key handler, plural-rules cache, and warn-once memo. On each `get()` it walks a resolved locale chain in order; within each locale it queries every store **in parallel** and picks the first hit (in declared store order).
 
 Higher-layer packages (`@ilingo/vue`, `@ilingo/vuelidate`) wrap the orchestrator for a specific framework — Vue's `provide`/`inject` makes the `Ilingo` instance and locale `Ref` available to descendants of the app root.
 
 ## Core Design Decisions
 
-### 1. Multi-store, first-hit lookup
+### 1. Locale-first walk with fallback chain
 
-`Ilingo` holds a **set** of stores, not just one. On `get()` it walks them in insertion order and returns the first non-`undefined` message. This lets consumers layer stores — e.g. an `FSStore` for default translations plus an in-memory `MemoryStore` for runtime overrides. `merge(otherIlingo)` is the only supported way to combine two instances; it adds foreign stores that are not already present (identity check, not deep equality).
+`Ilingo.get(ctx)` resolves a locale **chain** before querying anything (`getResolvedLocaleChain`). The chain order is `[requested, ...explicit-or-BCP-47-parents, default]`, deduplicated, with `default` pinned at the terminal position so it cannot be reordered out by an earlier mention. The chain is walked locale-first: closer locale beats farther one *regardless of store insertion order*. The chain can be inspected via `getResolvedLocaleChain(ctx)`; the locale that actually yielded a value is reachable via `getResolvedLocale(ctx)`.
 
-### 2. Group/key model
+### 2. Parallel store query within a locale
 
-Translations are addressed by `(locale, group, key)`. The `group` is a logical namespace — typically a filename when using `FSStore` (`packages/fs/src/module.ts` resolves `<directory>/<locale>/<group>.{js,mjs,cjs,ts,mts,json,conf}`). The `key` is a `pathtrace`-style dotted path within that group's nested object (see `MemoryStore.get` using `getPathValue`).
+For each locale in the chain, the orchestrator issues `store.get(...)` for every store **concurrently** via `Promise.all`, then picks the first hit in declared insertion order. The locale-order semantics are preserved (closer locale always wins); only intra-locale I/O overlaps. Trade-off: stores later in declared order are still queried even when an earlier store would have hit — cheap for the in-memory + fs adapters here, but custom network-backed or side-effecting stores will see every call. Document this on custom stores that care.
 
-### 3. ESM-first, dependency-light
+### 3. Multi-store, identity-based deduping
 
-Each package's runtime dependencies are minimal — `pathtrace` and `smob` in core; `locter`, `pathe`, `smob` in `@ilingo/fs`. Vue and Vuelidate are declared as `peerDependencies`, not bundled. Builds produce a single `.mjs` per package (no CJS output is shipped today — the `require` conditions in subpath exports reference non-existent `.js` files; treat that as a known wart, not a contract).
+`Ilingo` holds a **set** of stores. `merge(otherIlingo)` is the only supported way to combine two instances; it adds foreign stores that are not already present (identity check, not deep equality). Set semantics keep `add` idempotent for the same reference.
+
+### 4. Group/key/count model
+
+Translations are addressed by `(locale, group, key)` plus an optional `count` for pluralization. The `group` is a logical namespace — typically a filename when using `FSStore` (`packages/fs/src/module.ts` resolves `<directory>/<locale>/<group>.{js,mjs,cjs,ts,mts,json,conf}`). The `key` is a `pathtrace`-style dotted path within that group's nested object.
+
+### 5. Plural leaves: explicit marker preferred
+
+A leaf can be either a plain `string` or a `PluralLeaf` (`{ zero?, one?, two?, few?, many?, other }`). Two storage forms are accepted:
+
+- **Explicit (recommended)** — `{ "@plural": { one, other, ... } }`. Detection keys off the marker so siblings with CLDR-category names cannot collide.
+- **Structural (back-compat)** — bare `{ one, other }` with all keys being CLDR categories and `other` present.
+
+The orchestrator selects a form using `Intl.PluralRules` keyed by the *resolved* locale (the one that actually matched). `Intl.PluralRules` instances are cached per locale on the `Ilingo` instance.
+
+### 6. ESM-first, dependency-light, browser-safe
+
+Each package's runtime dependencies are minimal — `pathtrace` and `smob` in core; `locter`, `pathe`, `smob` in `@ilingo/fs`. Vue and Vuelidate are declared as `peerDependencies`, not bundled. Core does not import `node:process` — `NODE_ENV` is read via a bare `process.env.NODE_ENV` literal (so Vite / Webpack DefinePlugin can replace it) wrapped in a `typeof process !== 'undefined'` guard for raw-browser execution.
 
 ## Design Patterns
 
@@ -31,71 +48,81 @@ Each package's runtime dependencies are minimal — `pathtrace` and `smob` in co
 Port — `packages/ilingo/src/store/types.ts`:
 
 ```typescript
-export type StoreGetContext = {
-    locale: string,
-    group: string,
-    key: string,
-};
-
-export type StoreSetContext = StoreGetContext & { value: string };
+export type StoreGetContext = { locale: string, group: string, key: string };
+export type StoreSetContext = StoreGetContext & { value: Leaf };
 
 export interface IStore {
-    get(context: StoreGetContext): Promise<string | undefined>;
+    get(context: StoreGetContext): Promise<Leaf | undefined>;
     set(context: StoreSetContext): Promise<void>;
     getLocales(): Promise<string[]>;
 }
 ```
 
-Adapter — `packages/ilingo/src/store/memory.ts`:
+Adapter — `packages/ilingo/src/store/memory.ts` (returns either form, normalized via `asPluralLeaf`):
 
 ```typescript
-export class MemoryStore implements IStore {
-    protected data: LocalesRecord;
-
-    constructor(options: MemoryStoreOptions) { this.data = options.data; }
-
-    async get(ctx: StoreGetContext): Promise<string | undefined> {
-        if (!this.data[ctx.locale] || !this.data[ctx.locale][ctx.group]) return undefined;
-        const out = getPathValue(this.data[ctx.locale][ctx.group], ctx.key);
-        return typeof out === 'string' ? out : undefined;
-    }
-    // set(...), getLocales()
+async get(ctx: StoreGetContext): Promise<Leaf | undefined> {
+    const group = this.data[ctx.locale]?.[ctx.group];
+    if (!group) return undefined;
+    const out = getPathValue(group, ctx.key);
+    if (typeof out === 'string') return out;
+    return asPluralLeaf(out); // unwraps `{ "@plural": ... }` or bare structural
 }
 ```
 
 Conventions:
 
-- New stores **implement `IStore`** rather than extending `MemoryStore` unless they want the in-memory cache (`FSStore` does extend it, using the parent map as a load cache).
-- All methods are async, even when synchronous — keep that contract; `Ilingo.get` `await`s every store call.
-- A miss is `undefined`. Do not throw on miss; throwing breaks the multi-store fallback loop.
+- New stores **implement `IStore`** rather than extending `MemoryStore` unless they want the in-memory cache (`FSStore` extends it, using the parent map as a load cache).
+- All methods are async, even when synchronous — keep that contract; `Ilingo.lookup` `await`s every store call.
+- A miss is `undefined`. Do not throw on miss; that breaks the fallback walk.
+- Returning a `PluralLeaf` is allowed but optional — string-only stores remain valid.
 
 ### Orchestrator Pattern (`Ilingo`)
 
 ```typescript
 async get(ctx: GetContext): Promise<string | undefined> {
-    let message: string | undefined;
-    for (const store of this.stores) {
-        message = await store.get({
-            locale: ctx.locale || this.getLocale(),
-            group: ctx.group,
-            key: ctx.key,
-        });
-        if (message) break;
+    const requestedLocale = ctx.locale ?? this.getLocale();
+    const chain = this.getResolvedLocaleChain({ locale: requestedLocale });
+
+    const hit = await this.lookup(chain, ctx);
+    if (!hit) return this.handleMissingKey(ctx, requestedLocale, chain);
+
+    const message = this.selectPluralForm(hit.leaf, hit.locale, ctx.count);
+    const data: Data = { ...(ctx.data || {}) };
+    if (typeof ctx.count === 'number' && typeof data.count === 'undefined') {
+        data.count = ctx.count;
     }
-    if (!message) return undefined;
-    return this.format(message, ctx.data || {});
+    return this.format(message, data);
+}
+
+protected async lookup(chain, ctx) {
+    const stores = Array.from(this.stores);
+    for (const locale of chain) {
+        const results = await Promise.all(stores.map(s => s.get({ locale, ...ctx })));
+        for (const candidate of results) {
+            if (typeof candidate !== 'undefined') return { locale, leaf: candidate };
+        }
+    }
 }
 ```
 
-`Ilingo` itself owns three things only: the locale (default `'en'` from `LOCALE_DEFAULT`), the ordered store set, and template formatting. Anything more specific — file I/O, validator messages, Vue reactivity — lives in a higher-layer package.
+`Ilingo` owns: the locale (default `'en'` from `LOCALE_DEFAULT`), the ordered store set, the fallback config, the missing-key handler, a per-instance `pluralRulesCache: Map<string, Intl.PluralRules>`, a per-instance `warnedKeys: Set<string>` for the default warn-once handler, and the `{{var}}` template formatter. Framework-specific concerns live in higher-layer packages.
+
+### Missing-key handler
+
+`Config.onMissingKey?: (ctx) => string | undefined`. Invoked when the chain × stores walk exhausts without a hit. Receives a `MissingKeyContext` carrying the *resolved* `locale` (never undefined) plus `resolvedLocale` = the chain terminator. Returning a string makes that string the result of `get()`; returning `undefined` keeps the result `undefined`.
+
+If `onMissingKey` is not configured, the built-in default warns once per `(requestedLocale, group, key)` per instance, silenced when `process.env.NODE_ENV === 'production'`. The warn-once set is per-instance so multiple `Ilingo` instances don't dedupe each other's warnings.
 
 ### Vue Plugin Pattern
 
-`@ilingo/vue` exposes `install(app, input)` and a default `Plugin` object. `applyInstallInput` is the heart of it — it is idempotent and merge-aware:
+`@ilingo/vue` exposes `install(app, input)` and a default `Plugin` object. `applyInstallInput` is the heart of it — idempotent and merge-aware:
 
 1. Read any already-`provide`d `Ilingo` instance and locale `Ref` from the app.
 2. Resolve the new `input`: nothing → fresh `Ilingo`; an `Ilingo` → merge into existing or use directly; an `Options { store, locale }` → add the store to the existing instance or create one.
 3. Provide the instance and locale only if they were not provided before — so calling `install` more than once does not clobber existing wiring.
+
+`useTranslation(ctx)` forwards `count` as `MaybeRef<number>` (unwrapped via `unref`) so plural selection is reactive to count changes the same way `data` is.
 
 `@ilingo/vuelidate` chains this: it calls `applyInstallInput`, then ensures its own `Store` (a `MemoryStore` pre-loaded with EN/DE/FR/ES validator translations) is registered if none is present yet.
 
@@ -103,47 +130,62 @@ async get(ctx: GetContext): Promise<string | undefined> {
 
 ```
 Input:
-  └── ctx: { group, key, locale?, data? }   (caller — code, <ITranslate>, or useTranslation())
+  └── ctx: { group, key, locale?, data?, count? }    (caller — code, <ITranslate>, useTranslation)
 
 Processing:
-  1. Ilingo.get() resolves the effective locale (ctx.locale ?? this.locale)
-  2. Iterates this.stores in insertion order
-       └── each store.get({ locale, group, key }) returns string | undefined
-  3. First non-undefined wins
-  4. template(message, data) — substitutes {{var}} placeholders from ctx.data
+  1. requestedLocale = ctx.locale ?? instance default
+  2. chain = resolveLocaleChain(requested, fallback config, LOCALE_DEFAULT)
+       └── e.g. 'pt-BR' → ['pt-BR', 'pt', 'en']  (default tail; opt out via fallback: false | [])
+  3. lookup(chain, ctx):
+       for each locale in chain:
+           Promise.all(stores.map(s => s.get({ locale, group, key })))
+           → first defined candidate (in declared store order) wins
+       → { locale: hitLocale, leaf: string | PluralLeaf }
+  4. If miss → handleMissingKey → onMissingKey or warn-once default
+  5. selectPluralForm(leaf, hitLocale, count)
+       └── Intl.PluralRules(hitLocale) [cached] selects category, falls back to 'other'
+  6. count auto-merges into data if absent
+  7. template(message, data) substitutes {{var}} placeholders
 
 Output:
-  └── Promise<string | undefined>           ('undefined' = no store had the key)
+  └── Promise<string | undefined>     ('undefined' = handler returned no string)
 ```
 
 ## Error Handling
 
 - Misses return `undefined`. They are never errors.
-- `FSStore.loadGroup` swallows the "already loaded" case (`isLoaded` short-circuit, marked `/* istanbul ignore next */`) — repeat lookups for the same group are cheap.
-- File-loading errors from `locter`/`load` propagate. There is no project-wide error wrapper; rely on the underlying error type.
-- `template()` (`packages/ilingo/src/utils/template.ts`) does **not** error on a missing data key — the `{{var}}` stays in the output. Vue's `useTranslation` falls back to `"${group}.${key}"` when `Ilingo.get` returns `undefined`.
+- `FSStore.loadGroup` short-circuits the "already loaded" case (`isLoaded` guard).
+- File-loading errors from `locter`/`load` propagate. There is no project-wide error wrapper.
+- `template()` does **not** error on a missing data key — the `{{var}}` stays in the output.
+- Vue's `useTranslation` falls back to `"${group}.${key}"` when `Ilingo.get` returns `undefined` (the orchestrator's `onMissingKey` runs first and may substitute).
 
 ## File Structure (architectural layers)
 
 ```text
 packages/ilingo/src/
-├── module.ts            ← orchestrator
-├── store/{types,memory} ← port + default adapter
-├── utils/               ← stateless helpers (template, identify, language)
-└── config/              ← typed input shape
+├── module.ts                ← orchestrator (Ilingo class)
+├── store/{types,memory}     ← port + default adapter
+├── utils/
+│   ├── locale.ts            ← bcp47Parents, resolveLocaleChain
+│   ├── identify.ts          ← isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord, PLURAL_MARKER
+│   ├── template.ts          ← {{var}} substitution
+│   └── language/            ← isBCP47LanguageCode + CLDR data
+└── config/                  ← typed input shape
 
-packages/fs/src/module.ts          ← second IStore adapter (FSStore)
-packages/vue/src/index.ts          ← framework integration (Vue plugin)
-packages/vuelidate/src/store.ts    ← preloaded MemoryStore for validator names
+packages/fs/src/module.ts            ← second IStore adapter (FSStore, persists set() as JSON)
+packages/vue/src/index.ts            ← framework integration (Vue plugin)
+packages/vuelidate/src/store.ts      ← preloaded MemoryStore for validator names
 ```
 
 ## Configuration
 
 There are no environment variables. All configuration is passed via constructor inputs:
 
-| Object                    | Shape                                                    |
-|---------------------------|----------------------------------------------------------|
-| `new Ilingo(input)`       | `{ store?: IStore, locale?: string }`                    |
-| `new MemoryStore(opts)`   | `{ data: LocalesRecord }`                                |
-| `new FSStore(input)`      | `{ directory?: string \| string[] }` (normalized to `string[]`) |
-| Vue `install(app, input)` | `Options { store, locale } \| Ilingo \| undefined`       |
+| Object                    | Shape                                                                                                                                |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `new Ilingo(input)`       | `{ store?: IStore, locale?: string, fallback?: Fallback, onMissingKey?: MissingKeyHandler }`                                          |
+| `new MemoryStore(opts)`   | `{ data: LocalesRecord }`                                                                                                            |
+| `new FSStore(input)`      | `{ directory?: string \| string[], writeDirectory?: string }`                                                                       |
+| Vue `install(app, input)` | `Options { store, locale } \| Ilingo \| undefined`                                                                                  |
+
+`Fallback = string | string[] | (locale) => string[] | false`. Explicit-empty forms (`[]`, `false`, or a resolver returning `[]`) opt out of fallback entirely — the chain is just `[locale]` with no default-locale tail.

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -19,6 +19,11 @@
 ## Workflow
 
 - After source changes, run `npm run lint` (top-level) and `npm run build` (top-level or `--workspace=packages/<pkg>`) before declaring a task done.
+- **Keep docs in sync with code.** Every change that touches an observable surface — new public API, behavior change, new config field, new file in `src/`, new test spec — updates the affected docs in the same commit:
+  - User-facing: `packages/<pkg>/README.md`.
+  - Agent docs: `.agents/architecture.md` for orchestration / data-flow / patterns; `.agents/structure.md` for the file tree; `.agents/testing.md` for new specs; this file for new conventions or tooling.
+  - Plan files in `.agents/plans/` flip their status from Ready → In review → Done as the work moves through PRs.
+  - Exceptions: pure internal refactors with no observable change, and one-line bug fixes that don't change semantics. Use judgment.
 - When adding a new public symbol, re-export it from the package's `src/index.ts` — that file is the public-API contract.
 - When changing an `IStore` method signature, update both adapters (`MemoryStore`, `FSStore`) in the same commit; they share the port interface.
 - When adding a new package, register it in `release-please-config.json` and in the root `README.md` package list. monoship will publish it on the next release if its `version` is not on the registry.

--- a/.agents/plans/002-resolution-path.md
+++ b/.agents/plans/002-resolution-path.md
@@ -1,6 +1,6 @@
 # Phase 2 — Resolution-path features
 
-**Status**: Blocked by Phase 1.
+**Status**: Done (PR opened from `feat/resolution-path`).
 **Tracks**: [#895](https://github.com/tada5hi/ilingo/issues/895), [#897](https://github.com/tada5hi/ilingo/issues/897), [#899](https://github.com/tada5hi/ilingo/issues/899).
 
 Three features that all change how `Ilingo.get()` resolves a `(locale, group, key)` to a string. Per #907's sequencing they ship together so the tests are written against the final lookup shape — landing them serially would force two test rewrites.
@@ -40,11 +40,12 @@ Three features that all change how `Ilingo.get()` resolves a `(locale, group, ke
 
 ## Acceptance
 
-- [ ] Plural catalogs round-trip through `MemoryStore` and `FSStore`.
-- [ ] `get({ group, key, count: 0 })` matches `zero` where defined, `other` otherwise.
-- [ ] `get({ ..., locale: 'pt-BR' })` falls back to `pt` then to the default in the documented order.
-- [ ] Default dev-mode warning fires exactly once per missing key per process (memoize the warning set).
-- [ ] All existing tests still pass with no opt-in needed (backwards compatible for `string` leaves).
+- [x] Plural catalogs round-trip through `MemoryStore` (and `FSStore`, since it extends it).
+- [x] `get({ group, key, count: 0 })` matches `zero` where defined, `other` otherwise (verified in Welsh and English).
+- [x] `get({ ..., locale: 'pt-BR' })` falls back through `pt` to `en` by default; explicit `fallback` overrides (string / array / function).
+- [x] Default dev-mode warning fires exactly once per `(locale, group, key)` per process.
+- [x] Pre-existing tests pass with one expected behaviour change: a missing-locale lookup now falls through to the default locale rather than returning `undefined`. The affected fs test was updated to reflect the new contract.
+- [x] `getResolvedLocale(ctx)` returns the locale in the chain that yielded a value; `undefined` when the key is missing in every locale.
 
 ## Why this wave
 

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -5,7 +5,7 @@ Phased roadmap for ilingo, sequenced to land coherent waves of work rather than 
 | Phase | File                                              | Status      | Tracks                          |
 |-------|---------------------------------------------------|-------------|---------------------------------|
 | 1     | [001-dependency-cleanup.md](001-dependency-cleanup.md) | Done        | Post-modernization hygiene      |
-| 2     | [002-resolution-path.md](002-resolution-path.md)       | Ready       | #895, #897, #899                |
+| 2     | [002-resolution-path.md](002-resolution-path.md)       | In review   | #895, #897, #899                |
 | 3     | [003-intl-formatters.md](003-intl-formatters.md)       | Blocked by 2| #896                            |
 | 4     | [004-type-safe-keys.md](004-type-safe-keys.md)         | Blocked by 2| #898                            |
 | 5     | [005-vue-ergonomics.md](005-vue-ergonomics.md)         | Blocked by 2| #900, #901, #902                |

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -36,27 +36,35 @@ Nx (`nx.json`) is configured so `build` depends on `^build`, which means workspa
 ```
 src/
 ├── index.ts                  # barrel: re-exports config, module, store, utils, types
-├── module.ts                 # Ilingo class — holds Set<IStore>, locale, merge/get/getLocales
-├── types.ts                  # LinesRecord, GroupsRecord, LocalesRecord, GetContext, Data
+├── module.ts                 # Ilingo class — Set<IStore>, locale + fallback chain, plural rules cache,
+│                             #   per-instance warn-once memo, get / getResolvedLocale[Chain] / merge / format
+├── types.ts                  # LinesRecord, Leaf, PluralLeaf, PluralLeafExplicit, GetContext (with count),
+│                             #   MissingKeyContext, MissingKeyHandler, Fallback, FallbackResolver, Data
 ├── constants.ts              # LOCALE_DEFAULT = 'en'
 ├── config/
 │   ├── index.ts
-│   └── type.ts               # Config { store, locale }; ConfigInput = Partial<Config>
+│   └── type.ts               # Config { store, locale, fallback, onMissingKey }; ConfigInput = Partial<Config>
 ├── store/
 │   ├── index.ts              # barrel
-│   ├── types.ts              # IStore port, StoreGetContext, StoreSetContext, MemoryStoreOptions
-│   └── memory.ts             # MemoryStore (default in-memory IStore implementation)
+│   ├── types.ts              # IStore port, StoreGetContext, StoreSetContext (value: Leaf), MemoryStoreOptions
+│   └── memory.ts             # MemoryStore — returns string | PluralLeaf | undefined
 └── utils/
     ├── index.ts
-    ├── identify.ts           # isLineRecord type guard
+    ├── locale.ts             # bcp47Parents, resolveLocaleChain
+    ├── identify.ts           # PLURAL_MARKER + isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord
     ├── template.ts           # {{var}} interpolation
     └── language/
         ├── index.ts
         ├── module.ts         # isBCP47LanguageCode
         └── data.json         # BCP-47 language code table
 test/
-├── unit/                     # vitest specs mirroring src/
-└── data/                     # fixture locale files (.ts/.js/.json) consumed by spec runs
+└── unit/
+    ├── module.spec.ts        # legacy core behaviour
+    ├── resolution.spec.ts    # plural, fallback chain, missing-key handler, parallel lookup
+    └── utils/
+        ├── locale.spec.ts    # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
+        ├── identify.spec.ts
+        └── template.spec.ts
 ```
 
 ### `packages/fs/` — file-system adapter
@@ -64,11 +72,14 @@ test/
 ```
 src/
 ├── index.ts                  # barrel
-├── module.ts                 # FSStore extends MemoryStore — directory[], lazy loadGroup()
-├── types.ts                  # ConfigInput, Config
-└── utils.ts                  # buildConfig (normalize directory to string[])
+├── module.ts                 # FSStore extends MemoryStore — directory[], writeDirectory,
+│                             #   lazy loadGroup(), atomic persist() (write-tmp + rename)
+├── types.ts                  # ConfigInput, Config (now includes writeDirectory)
+└── utils.ts                  # buildConfig (normalize directory[] + writeDirectory)
 test/
-├── unit/module.spec.ts       # loads test/data/language/<locale>/<group>.* via FSStore
+├── unit/
+│   ├── module.spec.ts        # loads test/data/language/<locale>/<group>.* via FSStore
+│   └── persist.spec.ts       # set() round-trip, sibling preservation, split read/write dirs
 └── data/language/{en,de,fr}/form.{cjs,ts,json}
 ```
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -27,9 +27,13 @@ Nx caches `test` (see `nx.json` → `cacheableOperations`). To re-run an already
 
 ```
 unit/
-├── module.spec.ts              # Ilingo + MemoryStore: get/set, locale switching, merge()
+├── module.spec.ts              # legacy core behaviour — get/set, locale switching, merge()
+├── resolution.spec.ts          # pluralization (incl. explicit @plural form), fallback chain
+│                               #   (default, string, array, function, false, []), missing-key handler,
+│                               #   per-instance warn isolation, parallel intra-locale lookup
 └── utils/
-    ├── identify.spec.ts        # isLineRecord type guard
+    ├── identify.spec.ts        # isLineRecord / isPluralLeaf / isPluralLeafExplicit
+    ├── locale.spec.ts          # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
     └── template.spec.ts        # {{var}} interpolation
 data/
 └── language/{en,de,fr}/form.{js,ts,json}   # cross-extension loader fixtures
@@ -39,7 +43,9 @@ data/
 
 ```
 unit/
-└── module.spec.ts              # FSStore.loadGroup against test/data/language/
+├── module.spec.ts              # FSStore.loadGroup against test/data/language/ + fallback semantics
+└── persist.spec.ts             # set() round-trip, sibling preservation, nested keys,
+                                #   split read/write directories
 data/
 └── language/{en,de,fr}/form.{cjs,ts,json}  # exercises locter's multi-extension resolution
 ```
@@ -54,7 +60,9 @@ data/
 
 ## Testing Philosophy
 
-Tests assert the **public contract** of `Ilingo` and the stores — the things documented in `architecture.md`: first-hit lookup across stores, fallback to the default locale, `{{var}}` substitution, `merge()` deduping by reference identity. If a test fails after a refactor, treat it as a real regression on that contract until proven otherwise.
+Tests assert the **public contract** of `Ilingo` and the stores — the things documented in `architecture.md`: locale-first walk with fallback chain, parallel intra-locale store query, plural selection via `Intl.PluralRules`, missing-key handler routing, `{{var}}` substitution, `merge()` deduping by reference identity. If a test fails after a refactor, treat it as a real regression on that contract until proven otherwise.
+
+For timing-sensitive tests (concurrent store entry, debounce, etc.), assert the **invariant** (e.g. both store calls entered within the same tick) rather than wall-clock thresholds — the latter flakes on CI scheduler jitter.
 
 ### Fakes Over Mocks
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ reports
 .env
 coverage
 .nx
+.claude/settings.local.json
+.agents/plans

--- a/packages/fs/test/unit/module.spec.ts
+++ b/packages/fs/test/unit/module.spec.ts
@@ -134,8 +134,7 @@ describe('src/store/file-system', function () {
 
         // 'ru' has no data, but the default fallback chain now reaches 'en',
         // which does have `form.maxLength` — so the key resolves through the
-        // fallback. Opt out by passing an empty fallback to assert the old
-        // behaviour.
+        // fallback.
         let line = await language.get({
             group: 'form',
             key: 'maxLength',
@@ -152,4 +151,18 @@ describe('src/store/file-system', function () {
         });
         expect(line).toBeUndefined();
     })
+
+    it('should not translate when fallback is disabled (fallback: false)', async () => {
+        const language = new Ilingo({ store, fallback: false });
+
+        // With `fallback: false` the chain is just ['ru']; since 'ru' has no
+        // data the lookup misses without falling through to the default.
+        const line = await language.get({
+            group: 'form',
+            key: 'maxLength',
+            data: { max: 10 },
+            locale: 'ru',
+        });
+        expect(line).toBeUndefined();
+    });
 });

--- a/packages/fs/test/unit/module.spec.ts
+++ b/packages/fs/test/unit/module.spec.ts
@@ -132,6 +132,10 @@ describe('src/store/file-system', function () {
     it('should not translate async', async () => {
         const language = new Ilingo({ store });
 
+        // 'ru' has no data, but the default fallback chain now reaches 'en',
+        // which does have `form.maxLength` — so the key resolves through the
+        // fallback. Opt out by passing an empty fallback to assert the old
+        // behaviour.
         let line = await language.get({
             group: 'form',
             key: 'maxLength',
@@ -140,7 +144,7 @@ describe('src/store/file-system', function () {
             },
             locale: 'ru'
         });
-        expect(line).toBeUndefined();
+        expect(line).toEqual('The length of the input must be less than 10.');
 
         line = await language.get({
             group: 'form',

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -18,6 +18,9 @@ Ilingo is a lightweight library for translation and internationalization.
   - [Parameters](#parameters)
   - [Locales](#locales)
   - [Lazy](#lazy)
+  - [Pluralization](#pluralization)
+  - [Fallback locale chain](#fallback-locale-chain)
+  - [Missing-key handler](#missing-key-handler)
 - [Store](#store)
   - [Memory](#memory-store)
   - [FileSystem](#fs-store)
@@ -257,6 +260,68 @@ await ilingo.get({
     locale: 'de'
 });
 // boz y
+```
+
+### Pluralization
+
+Leaves may be CLDR plural objects keyed by category (`zero | one | two | few | many | other`); the matching form is selected via `Intl.PluralRules`. The `count` is automatically merged into `data` so `{{count}}` works without restating it.
+
+```typescript
+const ilingo = new Ilingo({
+    store: new MemoryStore({
+        data: {
+            en: {
+                cart: {
+                    items: {
+                        one: '{{count}} item',
+                        other: '{{count}} items',
+                    },
+                },
+            },
+        },
+    }),
+});
+
+await ilingo.get({ group: 'cart', key: 'items', count: 1 });
+// "1 item"
+await ilingo.get({ group: 'cart', key: 'items', count: 5 });
+// "5 items"
+```
+
+If the selected category is absent from the leaf, `other` is used as a fallback.
+
+### Fallback locale chain
+
+`get()` walks an ordered fallback chain. By default the chain is derived from BCP-47 parents of the requested locale, terminating at `en`:
+
+```typescript
+new Ilingo({ locale: 'pt-BR' }).getResolvedLocaleChain({ locale: 'pt-BR' });
+// ['pt-BR', 'pt', 'en']
+```
+
+Override with `fallback`:
+
+```typescript
+new Ilingo({ fallback: 'es' });            // string
+new Ilingo({ fallback: ['es', 'fr'] });    // array, in order
+new Ilingo({                               // function: per-call
+    fallback: (locale) => locale.startsWith('pt') ? ['es'] : [],
+});
+```
+
+The chain is walked locale-first across all stores — the closest locale match wins regardless of store order. Inspect the resolution with `await ilingo.getResolvedLocale({ group, key })`.
+
+### Missing-key handler
+
+Override the default dev-mode `console.warn` via `onMissingKey`. Return a string to make it the result of `get()`; return `undefined` to keep the result `undefined`.
+
+```typescript
+const ilingo = new Ilingo({
+    onMissingKey: ({ group, key, resolvedLocale }) => {
+        track('i18n.miss', { group, key, locale: resolvedLocale });
+        return `[missing: ${group}.${key}]`;
+    },
+});
 ```
 
 ## Store

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -315,6 +315,8 @@ If the selected category is absent from the leaf, `other` is used as a fallback.
 
 Structural detection (a bare `{ one, other }` object without the marker) is still supported for backward compatibility.
 
+Plural leaves round-trip through `store.set()` — `StoreSetContext.value` accepts either a `string` or a `PluralLeaf`. The `FSStore.set` persistence writes them as JSON unchanged.
+
 ### Fallback locale chain
 
 `get()` walks an ordered fallback chain. By default the chain is derived from BCP-47 parents of the requested locale, terminating at `en`:
@@ -336,7 +338,18 @@ new Ilingo({ fallback: false });           // disable fallback entirely
 new Ilingo({ fallback: [] });              // equivalent to `false`
 ```
 
-The chain is walked locale-first across all stores — the closest locale match wins regardless of store order. Inspect the resolution with `await ilingo.getResolvedLocale({ group, key })`.
+The chain is walked locale-first across all stores — the closest locale match wins regardless of store order. Within a single locale, every store is queried **in parallel** (`Promise.all`) and the first hit in declared insertion order is returned. For the in-memory and fs adapters this is essentially free; custom network-backed or side-effecting stores should expect every call within a locale even when an earlier store would have hit.
+
+Inspect the resolution with:
+
+```typescript
+ilingo.getResolvedLocaleChain({ locale: 'pt-BR' });
+// ['pt-BR', 'pt', 'en']
+
+await ilingo.getResolvedLocale({ group: 'app', key: 'hi' });
+// 'pt'   — which locale actually yielded a value
+// undefined if no store had the key anywhere in the chain
+```
 
 ### Missing-key handler
 

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -307,6 +307,7 @@ new Ilingo({ fallback: ['es', 'fr'] });    // array, in order
 new Ilingo({                               // function: per-call
     fallback: (locale) => locale.startsWith('pt') ? ['es'] : [],
 });
+new Ilingo({ fallback: false });           // disable fallback entirely
 ```
 
 The chain is walked locale-first across all stores — the closest locale match wins regardless of store order. Inspect the resolution with `await ilingo.getResolvedLocale({ group, key })`.

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -290,6 +290,31 @@ await ilingo.get({ group: 'cart', key: 'items', count: 5 });
 
 If the selected category is absent from the leaf, `other` is used as a fallback.
 
+**Recommended explicit form.** Prefer wrapping plural forms in `{ "@plural": { ... } }` to disambiguate them from regular namespaces that happen to use CLDR category names:
+
+```typescript
+{
+    en: {
+        cart: {
+            items: {
+                '@plural': {
+                    one: '{{count}} item',
+                    other: '{{count}} items',
+                },
+            },
+        },
+        form: {
+            kind: {
+                // Plain namespaces with CLDR-category-shaped keys are safe.
+                other: { label: 'Other' },
+            },
+        },
+    },
+}
+```
+
+Structural detection (a bare `{ one, other }` object without the marker) is still supported for backward compatibility.
+
 ### Fallback locale chain
 
 `get()` walks an ordered fallback chain. By default the chain is derived from BCP-47 parents of the requested locale, terminating at `en`:

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -333,6 +333,7 @@ new Ilingo({                               // function: per-call
     fallback: (locale) => locale.startsWith('pt') ? ['es'] : [],
 });
 new Ilingo({ fallback: false });           // disable fallback entirely
+new Ilingo({ fallback: [] });              // equivalent to `false`
 ```
 
 The chain is walked locale-first across all stores — the closest locale match wins regardless of store order. Inspect the resolution with `await ilingo.getResolvedLocale({ group, key })`.

--- a/packages/ilingo/src/config/type.ts
+++ b/packages/ilingo/src/config/type.ts
@@ -1,9 +1,25 @@
 import type { IStore } from '../store';
+import type { Fallback, MissingKeyHandler } from '../types';
 
 export type Config = {
     store: IStore,
     // default: en
     locale: string,
+    /**
+     * Fallback locale chain for `Ilingo.get()`.
+     *
+     * - `string`        → tried after the requested locale, before the default.
+     * - `string[]`      → same as above with multiple entries, applied in order.
+     * - `(locale) => string[]` → computed per call.
+     * - `undefined`     → derived from BCP-47 parents of the requested locale.
+     */
+    fallback: Fallback,
+    /**
+     * Called when no store yields a value for the key after the fallback chain
+     * is exhausted. Returning a string makes that string the result of `get()`;
+     * returning `undefined` (or nothing) keeps `get()`'s result `undefined`.
+     */
+    onMissingKey: MissingKeyHandler,
 };
 
 export type ConfigInput = Partial<Config>;

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -13,44 +13,31 @@ import type {
     Fallback,
     GetContext,
     Leaf,
-    MissingKeyContext,
     MissingKeyHandler,
-    PluralLeaf,
 } from './types';
 import {
-    isPluralLeaf,
     resolveLocaleChain,
     template,
 } from './utils';
 
-const warnedKeys = new Set<string>();
-
 /**
- * Read `process.env.NODE_ENV` without importing `node:process`, so the core
- * module stays browser-safe. `globalThis.process` may be `undefined` in
- * browsers; tolerate that without throwing.
+ * `true` when running under a production bundle.
+ *
+ * Webpack's DefinePlugin and Vite's `define` replace the literal expression
+ * `process.env.NODE_ENV` at build time. We reference it directly (rather
+ * than via `globalThis`) so that replacement actually fires. The
+ * `typeof process !== 'undefined'` guard makes raw-browser execution
+ * (no polyfill, no bundler) safe.
  */
-function getNodeEnv(): string | undefined {
-    const p = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
-    return p?.env?.NODE_ENV;
-}
-
-function defaultMissingKeyHandler(ctx: MissingKeyContext): undefined {
+function isProductionEnv(): boolean {
     /* istanbul ignore next */
-    if (getNodeEnv() === 'production') {
-        return undefined;
+    try {
+        return typeof process !== 'undefined' &&
+            process.env != null &&
+            process.env.NODE_ENV === 'production';
+    } catch {
+        return false;
     }
-    const requestedLocale = ctx.locale ?? 'unknown';
-    const id = `${requestedLocale}|${ctx.group}|${ctx.key}`;
-    if (!warnedKeys.has(id)) {
-        warnedKeys.add(id);
-        // eslint-disable-next-line no-console
-        console.warn(
-            `[ilingo] missing translation for "${ctx.group}.${ctx.key}" ` +
-            `(locale=${requestedLocale})`,
-        );
-    }
-    return undefined;
 }
 
 export class Ilingo {
@@ -60,17 +47,26 @@ export class Ilingo {
 
     protected fallback: Fallback | undefined;
 
-    protected onMissingKey: MissingKeyHandler;
+    protected onMissingKey: MissingKeyHandler | undefined;
 
     protected pluralRulesCache: Map<string, Intl.PluralRules>;
+
+    /**
+     * Per-instance set of `(locale, group, key)` triples that have already
+     * triggered a missing-key warning. Kept on the instance — not module
+     * scope — so multiple `Ilingo` instances do not dedupe each other's
+     * warnings.
+     */
+    protected warnedKeys: Set<string>;
 
     // ----------------------------------------------------
 
     constructor(input: ConfigInput = {}) {
         this.locale = input.locale || LOCALE_DEFAULT;
         this.fallback = input.fallback;
-        this.onMissingKey = input.onMissingKey || defaultMissingKeyHandler;
+        this.onMissingKey = input.onMissingKey;
         this.pluralRulesCache = new Map();
+        this.warnedKeys = new Set();
 
         this.stores = new Set<IStore>();
         if (input.store) {
@@ -140,19 +136,8 @@ export class Ilingo {
      */
     async getResolvedLocale(ctx: GetContext): Promise<string | undefined> {
         const chain = this.getResolvedLocaleChain(ctx);
-        for (const locale of chain) {
-            for (const store of this.stores) {
-                const leaf = await store.get({
-                    locale,
-                    group: ctx.group,
-                    key: ctx.key,
-                });
-                if (typeof leaf !== 'undefined') {
-                    return locale;
-                }
-            }
-        }
-        return undefined;
+        const hit = await this.lookup(chain, ctx);
+        return hit?.locale;
     }
 
     // ----------------------------------------------------
@@ -162,19 +147,12 @@ export class Ilingo {
         const chain = this.getResolvedLocaleChain({ locale: requestedLocale });
 
         const hit = await this.lookup(chain, ctx);
-        const resolvedLocale = hit?.locale;
-        const leaf = hit?.leaf;
 
-        if (typeof leaf === 'undefined') {
-            const fallback = this.onMissingKey({
-                ...ctx,
-                locale: requestedLocale,
-                resolvedLocale: chain[chain.length - 1],
-            });
-            return typeof fallback === 'string' ? fallback : undefined;
+        if (!hit) {
+            return this.handleMissingKey(ctx, requestedLocale, chain);
         }
 
-        const message = this.selectPluralForm(leaf, resolvedLocale ?? requestedLocale, ctx.count);
+        const message = this.selectPluralForm(hit.leaf, hit.locale, ctx.count);
         const data: Data = { ...(ctx.data || {}) };
         if (typeof ctx.count === 'number' && typeof data.count === 'undefined') {
             data.count = ctx.count;
@@ -190,7 +168,7 @@ export class Ilingo {
      */
     protected async lookup(
         chain: string[],
-        ctx: GetContext,
+        ctx: Pick<GetContext, 'group' | 'key'>,
     ): Promise<{ locale: string, leaf: Leaf } | undefined> {
         for (const locale of chain) {
             for (const store of this.stores) {
@@ -208,6 +186,41 @@ export class Ilingo {
     }
 
     /**
+     * Run the configured `onMissingKey` (or the built-in warn-once default)
+     * and return whatever it produces.
+     */
+    protected handleMissingKey(
+        ctx: GetContext,
+        requestedLocale: string,
+        chain: string[],
+    ): string | undefined {
+        if (this.onMissingKey) {
+            const result = this.onMissingKey({
+                ...ctx,
+                locale: requestedLocale,
+                resolvedLocale: chain[chain.length - 1],
+            });
+            return typeof result === 'string' ? result : undefined;
+        }
+
+        /* istanbul ignore next */
+        if (isProductionEnv()) {
+            return undefined;
+        }
+
+        const id = `${requestedLocale}|${ctx.group}|${ctx.key}`;
+        if (!this.warnedKeys.has(id)) {
+            this.warnedKeys.add(id);
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[ilingo] missing translation for "${ctx.group}.${ctx.key}" ` +
+                `(locale=${requestedLocale})`,
+            );
+        }
+        return undefined;
+    }
+
+    /**
      * Pick the matching plural form for `count`. Pass-through when the leaf
      * is already a string. Falls back to `other` if the selected category
      * isn't present.
@@ -220,7 +233,7 @@ export class Ilingo {
             return leaf.other;
         }
         const category = this.getPluralRules(locale).select(count);
-        const candidate = (leaf as PluralLeaf)[category];
+        const candidate = leaf[category];
         return typeof candidate === 'string' ? candidate : leaf.other;
     }
 
@@ -231,11 +244,6 @@ export class Ilingo {
             this.pluralRulesCache.set(locale, rules);
         }
         return rules;
-    }
-
-    /* istanbul ignore next */
-    protected isPluralLeaf(value: unknown): value is PluralLeaf {
-        return isPluralLeaf(value);
     }
 
     // ----------------------------------------------------

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -5,25 +5,59 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import process from 'node:process';
 import type { ConfigInput } from './config';
 import { LOCALE_DEFAULT } from './constants';
 import type { IStore } from './store';
 import type {
+    Data,
+    Fallback,
     GetContext,
+    Leaf,
+    MissingKeyContext,
+    MissingKeyHandler,
+    PluralLeaf,
 } from './types';
 import {
+    isPluralLeaf,
+    resolveLocaleChain,
     template,
 } from './utils';
 
+const warnedKeys = new Set<string>();
+
+function defaultMissingKeyHandler(ctx: MissingKeyContext): undefined {
+    /* istanbul ignore next */
+    if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') {
+        return undefined;
+    }
+    const id = `${ctx.resolvedLocale ?? ctx.locale ?? ''}|${ctx.group}|${ctx.key}`;
+    if (!warnedKeys.has(id)) {
+        warnedKeys.add(id);
+        // eslint-disable-next-line no-console
+        console.warn(
+            `[ilingo] missing translation for "${ctx.group}.${ctx.key}" ` +
+            `(locale=${ctx.resolvedLocale ?? ctx.locale ?? 'unknown'})`,
+        );
+    }
+    return undefined;
+}
+
 export class Ilingo {
-    public readonly stores : Set<IStore>;
+    public readonly stores: Set<IStore>;
 
     protected locale: string;
+
+    protected fallback: Fallback | undefined;
+
+    protected onMissingKey: MissingKeyHandler;
 
     // ----------------------------------------------------
 
     constructor(input: ConfigInput = {}) {
         this.locale = input.locale || LOCALE_DEFAULT;
+        this.fallback = input.fallback;
+        this.onMissingKey = input.onMissingKey || defaultMissingKeyHandler;
 
         this.stores = new Set<IStore>();
         if (input.store) {
@@ -62,55 +96,122 @@ export class Ilingo {
         this.locale = LOCALE_DEFAULT;
     }
 
-    getLocale() : string {
+    getLocale(): string {
         return this.locale;
     }
 
     // ----------------------------------------------------
 
-    async getLocales() : Promise<string[]> {
-        const locales : string[] = [];
-        const entries = this.stores.values();
-         
-        while (true) {
-            const store = entries.next();
-            if (store.done) {
-                break;
-            }
-
-            locales.push(...await store.value.getLocales());
+    async getLocales(): Promise<string[]> {
+        const locales: string[] = [];
+        for (const store of this.stores) {
+            locales.push(...await store.getLocales());
         }
         return Array.from(new Set(locales));
     }
 
+    /**
+     * Locale chain that would be tried for the given context, in order.
+     */
+    getResolvedLocaleChain(ctx: Pick<GetContext, 'locale'>): string[] {
+        return resolveLocaleChain(
+            ctx.locale || this.getLocale(),
+            this.fallback,
+            LOCALE_DEFAULT,
+        );
+    }
+
+    /**
+     * Which locale in the chain actually yielded a value for the given
+     * `(group, key)`, or `undefined` if the key is missing in every locale.
+     */
+    async getResolvedLocale(ctx: GetContext): Promise<string | undefined> {
+        const chain = this.getResolvedLocaleChain(ctx);
+        for (const locale of chain) {
+            for (const store of this.stores) {
+                const leaf = await store.get({
+                    locale,
+                    group: ctx.group,
+                    key: ctx.key,
+                });
+                if (typeof leaf !== 'undefined') {
+                    return locale;
+                }
+            }
+        }
+        return undefined;
+    }
+
     // ----------------------------------------------------
 
-    async get(ctx: GetContext) : Promise<string | undefined> {
-        let message : string | undefined;
-        const entries = this.stores.values();
-         
-        while (true) {
-            const store = entries.next();
-            if (store.done) {
-                break;
-            }
+    async get(ctx: GetContext): Promise<string | undefined> {
+        const chain = this.getResolvedLocaleChain(ctx);
 
-            message = await store.value.get({
-                locale: ctx.locale || this.getLocale(),
-                group: ctx.group,
-                key: ctx.key,
+        const hit = await this.lookup(chain, ctx);
+        const resolvedLocale = hit?.locale;
+        const leaf = hit?.leaf;
+
+        if (typeof leaf === 'undefined') {
+            const fallback = this.onMissingKey({
+                ...ctx,
+                resolvedLocale: chain[chain.length - 1],
             });
+            return typeof fallback === 'string' ? fallback : undefined;
+        }
 
-            if (message) {
-                break;
+        const message = this.selectPluralForm(leaf, resolvedLocale ?? this.getLocale(), ctx.count);
+        const data: Data = { ...(ctx.data || {}) };
+        if (typeof ctx.count === 'number' && typeof data.count === 'undefined') {
+            data.count = ctx.count;
+        }
+        return this.format(message, data);
+    }
+
+    // ----------------------------------------------------
+
+    /**
+     * Walk the locale chain (then each store within a locale) and return the
+     * first hit. Returns `undefined` when every store misses for every locale.
+     */
+    protected async lookup(
+        chain: string[],
+        ctx: GetContext,
+    ): Promise<{ locale: string, leaf: Leaf } | undefined> {
+        for (const locale of chain) {
+            for (const store of this.stores) {
+                const candidate = await store.get({
+                    locale,
+                    group: ctx.group,
+                    key: ctx.key,
+                });
+                if (typeof candidate !== 'undefined') {
+                    return { locale, leaf: candidate };
+                }
             }
         }
+        return undefined;
+    }
 
-        if (!message) {
-            return undefined;
+    /**
+     * Pick the matching plural form for `count`. Pass-through when the leaf
+     * is already a string. Falls back to `other` if the selected category
+     * isn't present.
+     */
+    protected selectPluralForm(leaf: Leaf, locale: string, count: number | undefined): string {
+        if (typeof leaf === 'string') {
+            return leaf;
         }
+        if (typeof count !== 'number') {
+            return leaf.other;
+        }
+        const category = new Intl.PluralRules(locale).select(count);
+        const candidate = (leaf as PluralLeaf)[category];
+        return typeof candidate === 'string' ? candidate : leaf.other;
+    }
 
-        return this.format(message, ctx.data || {});
+    /* istanbul ignore next */
+    protected isPluralLeaf(value: unknown): value is PluralLeaf {
+        return isPluralLeaf(value);
     }
 
     // ----------------------------------------------------

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -5,7 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import process from 'node:process';
 import type { ConfigInput } from './config';
 import { LOCALE_DEFAULT } from './constants';
 import type { IStore } from './store';
@@ -26,18 +25,29 @@ import {
 
 const warnedKeys = new Set<string>();
 
+/**
+ * Read `process.env.NODE_ENV` without importing `node:process`, so the core
+ * module stays browser-safe. `globalThis.process` may be `undefined` in
+ * browsers; tolerate that without throwing.
+ */
+function getNodeEnv(): string | undefined {
+    const p = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process;
+    return p?.env?.NODE_ENV;
+}
+
 function defaultMissingKeyHandler(ctx: MissingKeyContext): undefined {
     /* istanbul ignore next */
-    if (typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production') {
+    if (getNodeEnv() === 'production') {
         return undefined;
     }
-    const id = `${ctx.resolvedLocale ?? ctx.locale ?? ''}|${ctx.group}|${ctx.key}`;
+    const requestedLocale = ctx.locale ?? 'unknown';
+    const id = `${requestedLocale}|${ctx.group}|${ctx.key}`;
     if (!warnedKeys.has(id)) {
         warnedKeys.add(id);
         // eslint-disable-next-line no-console
         console.warn(
             `[ilingo] missing translation for "${ctx.group}.${ctx.key}" ` +
-            `(locale=${ctx.resolvedLocale ?? ctx.locale ?? 'unknown'})`,
+            `(locale=${requestedLocale})`,
         );
     }
     return undefined;
@@ -52,12 +62,15 @@ export class Ilingo {
 
     protected onMissingKey: MissingKeyHandler;
 
+    protected pluralRulesCache: Map<string, Intl.PluralRules>;
+
     // ----------------------------------------------------
 
     constructor(input: ConfigInput = {}) {
         this.locale = input.locale || LOCALE_DEFAULT;
         this.fallback = input.fallback;
         this.onMissingKey = input.onMissingKey || defaultMissingKeyHandler;
+        this.pluralRulesCache = new Map();
 
         this.stores = new Set<IStore>();
         if (input.store) {
@@ -145,7 +158,8 @@ export class Ilingo {
     // ----------------------------------------------------
 
     async get(ctx: GetContext): Promise<string | undefined> {
-        const chain = this.getResolvedLocaleChain(ctx);
+        const requestedLocale = ctx.locale ?? this.getLocale();
+        const chain = this.getResolvedLocaleChain({ locale: requestedLocale });
 
         const hit = await this.lookup(chain, ctx);
         const resolvedLocale = hit?.locale;
@@ -154,12 +168,13 @@ export class Ilingo {
         if (typeof leaf === 'undefined') {
             const fallback = this.onMissingKey({
                 ...ctx,
+                locale: requestedLocale,
                 resolvedLocale: chain[chain.length - 1],
             });
             return typeof fallback === 'string' ? fallback : undefined;
         }
 
-        const message = this.selectPluralForm(leaf, resolvedLocale ?? this.getLocale(), ctx.count);
+        const message = this.selectPluralForm(leaf, resolvedLocale ?? requestedLocale, ctx.count);
         const data: Data = { ...(ctx.data || {}) };
         if (typeof ctx.count === 'number' && typeof data.count === 'undefined') {
             data.count = ctx.count;
@@ -204,9 +219,18 @@ export class Ilingo {
         if (typeof count !== 'number') {
             return leaf.other;
         }
-        const category = new Intl.PluralRules(locale).select(count);
+        const category = this.getPluralRules(locale).select(count);
         const candidate = (leaf as PluralLeaf)[category];
         return typeof candidate === 'string' ? candidate : leaf.other;
+    }
+
+    protected getPluralRules(locale: string): Intl.PluralRules {
+        let rules = this.pluralRulesCache.get(locale);
+        if (!rules) {
+            rules = new Intl.PluralRules(locale);
+            this.pluralRulesCache.set(locale, rules);
+        }
+        return rules;
     }
 
     /* istanbul ignore next */

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -163,20 +163,35 @@ export class Ilingo {
     // ----------------------------------------------------
 
     /**
-     * Walk the locale chain (then each store within a locale) and return the
-     * first hit. Returns `undefined` when every store misses for every locale.
+     * Walk the locale chain in order. Within each locale, query every store
+     * in parallel and pick the first store (in declared insertion order) that
+     * returned a hit.
+     *
+     * Locale order is preserved (closer locale beats farther one), but for a
+     * single locale the I/O of multiple stores overlaps. The trade-off is that
+     * stores later in the insertion order are still queried even when an
+     * earlier store would have hit — wasted work for network-backed stores
+     * but cheap for the in-memory + fs adapters shipped here. Custom stores
+     * with side effects (e.g. metrics) will see every call.
      */
     protected async lookup(
         chain: string[],
         ctx: Pick<GetContext, 'group' | 'key'>,
     ): Promise<{ locale: string, leaf: Leaf } | undefined> {
+        const stores = Array.from(this.stores);
+        if (stores.length === 0) {
+            return undefined;
+        }
+
         for (const locale of chain) {
-            for (const store of this.stores) {
-                const candidate = await store.get({
+            const results = await Promise.all(
+                stores.map((store) => store.get({
                     locale,
                     group: ctx.group,
                     key: ctx.key,
-                });
+                })),
+            );
+            for (const candidate of results) {
                 if (typeof candidate !== 'undefined') {
                     return { locale, leaf: candidate };
                 }

--- a/packages/ilingo/src/store/memory.ts
+++ b/packages/ilingo/src/store/memory.ts
@@ -6,7 +6,8 @@
  */
 
 import { getPathValue, setPathValue } from 'pathtrace';
-import type { LocalesRecord } from '../types';
+import type { Leaf, LocalesRecord } from '../types';
+import { isPluralLeaf } from '../utils/identify';
 import type {
     IStore,
     MemoryStoreOptions,
@@ -15,13 +16,13 @@ import type {
 } from './types';
 
 export class MemoryStore implements IStore {
-    protected data : LocalesRecord;
+    protected data: LocalesRecord;
 
     constructor(options: MemoryStoreOptions) {
         this.data = options.data;
     }
 
-    async get(context: StoreGetContext): Promise<string | undefined> {
+    async get(context: StoreGetContext): Promise<Leaf | undefined> {
         if (
             !this.data[context.locale] ||
             !this.data[context.locale][context.group]
@@ -35,6 +36,10 @@ export class MemoryStore implements IStore {
         );
 
         if (typeof output === 'string') {
+            return output;
+        }
+
+        if (isPluralLeaf(output)) {
             return output;
         }
 

--- a/packages/ilingo/src/store/memory.ts
+++ b/packages/ilingo/src/store/memory.ts
@@ -7,7 +7,7 @@
 
 import { getPathValue, setPathValue } from 'pathtrace';
 import type { Leaf, LocalesRecord } from '../types';
-import { isPluralLeaf } from '../utils/identify';
+import { asPluralLeaf } from '../utils/identify';
 import type {
     IStore,
     MemoryStoreOptions,
@@ -39,11 +39,11 @@ export class MemoryStore implements IStore {
             return output;
         }
 
-        if (isPluralLeaf(output)) {
-            return output;
-        }
-
-        return undefined;
+        // Accept both the explicit `{ "@plural": { ... } }` wrapper and the
+        // structural bare `{ one, other }` form. `asPluralLeaf` returns the
+        // inner leaf in either case so callers (and the orchestrator) deal
+        // with one shape.
+        return asPluralLeaf(output);
     }
 
     async set(context: StoreSetContext): Promise<void> {

--- a/packages/ilingo/src/store/types.ts
+++ b/packages/ilingo/src/store/types.ts
@@ -5,26 +5,33 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { LocalesRecord } from '../types';
+import type { Leaf, LocalesRecord } from '../types';
 
 export type StoreGetContext = {
     locale: string,
     group: string,
-    key: string
+    key: string,
 };
 
 export type StoreSetContext = StoreGetContext & {
-    value: string
+    value: string,
 };
 
 export interface IStore {
-    get(context: StoreGetContext) : Promise<string | undefined>;
+    /**
+     * Resolve a `(locale, group, key)` to a leaf value.
+     *
+     * The leaf can be a plain string or a CLDR-categorised plural leaf
+     * (`{ one, other, ... }`). Implementations that don't support plural
+     * catalogs may return only `string | undefined`.
+     */
+    get(context: StoreGetContext): Promise<Leaf | undefined>;
 
-    set(context: StoreSetContext) : Promise<void>;
+    set(context: StoreSetContext): Promise<void>;
 
-    getLocales() : Promise<string[]>;
+    getLocales(): Promise<string[]>;
 }
 
 export type MemoryStoreOptions = {
-    data: LocalesRecord
+    data: LocalesRecord,
 };

--- a/packages/ilingo/src/store/types.ts
+++ b/packages/ilingo/src/store/types.ts
@@ -14,7 +14,7 @@ export type StoreGetContext = {
 };
 
 export type StoreSetContext = StoreGetContext & {
-    value: string,
+    value: Leaf,
 };
 
 export interface IStore {

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -5,12 +5,19 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export type PluralCategory = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
+
+export type PluralLeaf = { other: string } &
+    Partial<Record<Exclude<PluralCategory, 'other'>, string>>;
+
+export type Leaf = string | PluralLeaf;
+
 export type ValueOrNestedValue<T> = {
     [key: string]: ValueOrNestedValue<T> | T
 };
 
 // default: Record<group, Record<locale, Lines>>
-export type LinesRecord = ValueOrNestedValue<string>;
+export type LinesRecord = ValueOrNestedValue<Leaf>;
 // default: Record<group, Lines>
 export type GroupsRecord = Record<string, LinesRecord>;
 // default: Record<locale, Groups>
@@ -25,4 +32,18 @@ export type GetContext = {
     locale?: string,
     group: string,
     key: string,
+    count?: number,
 };
+
+export type MissingKeyContext = GetContext & {
+    /**
+     * The last locale that was tried — the end of the resolved fallback chain.
+     */
+    resolvedLocale?: string,
+};
+
+export type MissingKeyHandler = (context: MissingKeyContext) => string | undefined | void;
+
+export type FallbackResolver = (locale: string) => string[];
+
+export type Fallback = string | string[] | FallbackResolver;

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -7,6 +7,14 @@
 
 export type PluralCategory = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
 
+/**
+ * CLDR-categorised translation for a single key.
+ *
+ * Note: detection is structural (`isPluralLeaf`). A non-plural object whose
+ * only keys happen to be CLDR category names (e.g. `{ other: 'fallback' }`
+ * used as a regular namespace) will be interpreted as a plural leaf. Avoid
+ * naming nested groups after plural categories.
+ */
 export type PluralLeaf = { other: string } &
     Partial<Record<Exclude<PluralCategory, 'other'>, string>>;
 
@@ -42,7 +50,7 @@ export type MissingKeyContext = GetContext & {
     resolvedLocale?: string,
 };
 
-export type MissingKeyHandler = (context: MissingKeyContext) => string | undefined | void;
+export type MissingKeyHandler = (context: MissingKeyContext) => string | undefined;
 
 export type FallbackResolver = (locale: string) => string[];
 

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -64,9 +64,15 @@ export type FallbackResolver = (locale: string) => string[];
 
 /**
  * - `string`            — single fallback locale, applied after the requested one.
- * - `string[]`          — ordered fallback locales (empty array suppresses BCP-47 parents).
- * - `FallbackResolver`  — computed per call.
- * - `false`             — disable fallback entirely; the chain is just `[locale]`
- *                          (the default locale is NOT appended).
+ * - `string[]`          — ordered fallback locales. An *empty* array opts out
+ *                          of fallback entirely (chain is just `[locale]`).
+ * - `FallbackResolver`  — computed per call. Returning `[]` also opts out for
+ *                          that call.
+ * - `false`             — disable fallback entirely; equivalent to `[]` but
+ *                          type-safe to spell out the intent.
+ *
+ * If none of the explicit forms above are given (i.e. `undefined`), the chain
+ * is derived from BCP-47 parents of the requested locale and terminates at
+ * the default locale.
  */
 export type Fallback = string | string[] | FallbackResolver | false;

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -46,4 +46,11 @@ export type MissingKeyHandler = (context: MissingKeyContext) => string | undefin
 
 export type FallbackResolver = (locale: string) => string[];
 
-export type Fallback = string | string[] | FallbackResolver;
+/**
+ * - `string`            — single fallback locale, applied after the requested one.
+ * - `string[]`          — ordered fallback locales (empty array suppresses BCP-47 parents).
+ * - `FallbackResolver`  — computed per call.
+ * - `false`             — disable fallback entirely; the chain is just `[locale]`
+ *                          (the default locale is NOT appended).
+ */
+export type Fallback = string | string[] | FallbackResolver | false;

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -10,13 +10,21 @@ export type PluralCategory = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
 /**
  * CLDR-categorised translation for a single key.
  *
- * Note: detection is structural (`isPluralLeaf`). A non-plural object whose
- * only keys happen to be CLDR category names (e.g. `{ other: 'fallback' }`
- * used as a regular namespace) will be interpreted as a plural leaf. Avoid
- * naming nested groups after plural categories.
+ * Prefer the explicit form below (`PluralLeafExplicit`) — wrap your plural
+ * forms in `{ "@plural": { ... } }` — to avoid ambiguity with regular
+ * namespaces. Structural detection (recognising a bare `{ one, other }`
+ * object as plural) is supported for backward compatibility but is
+ * unambiguous only as long as no sibling key happens to be a CLDR
+ * category name.
  */
 export type PluralLeaf = { other: string } &
     Partial<Record<Exclude<PluralCategory, 'other'>, string>>;
+
+/**
+ * Recommended explicit form. Unambiguous regardless of sibling key names,
+ * since detection keys off the `@plural` discriminator.
+ */
+export type PluralLeafExplicit = { '@plural': PluralLeaf };
 
 export type Leaf = string | PluralLeaf;
 

--- a/packages/ilingo/src/utils/identify.ts
+++ b/packages/ilingo/src/utils/identify.ts
@@ -6,10 +6,43 @@
  */
 
 import { isObject } from 'smob';
-import type { LinesRecord } from '../types';
+import type { LinesRecord, PluralCategory, PluralLeaf } from '../types';
 
-export function isLineRecord(value: unknown) : value is LinesRecord {
+const PLURAL_CATEGORIES = new Set<PluralCategory>([
+    'zero', 
+    'one', 
+    'two', 
+    'few', 
+    'many', 
+    'other',
+]);
+
+export function isPluralLeaf(value: unknown): value is PluralLeaf {
     if (!isObject(value)) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 0 || typeof obj.other !== 'string') {
+        return false;
+    }
+    for (const key of keys) {
+        if (!PLURAL_CATEGORIES.has(key as PluralCategory)) {
+            return false;
+        }
+        if (typeof obj[key] !== 'string') {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function isLineRecord(value: unknown): value is LinesRecord {
+    if (!isObject(value)) {
+        return false;
+    }
+
+    if (isPluralLeaf(value)) {
         return false;
     }
 
@@ -19,6 +52,7 @@ export function isLineRecord(value: unknown) : value is LinesRecord {
         /* istanbul ignore next */
         if (
             typeof ob[key] !== 'string' &&
+            !isPluralLeaf(ob[key]) &&
             !isLineRecord(ob[key])
         ) {
             return false;

--- a/packages/ilingo/src/utils/identify.ts
+++ b/packages/ilingo/src/utils/identify.ts
@@ -6,17 +6,28 @@
  */
 
 import { isObject } from 'smob';
-import type { LinesRecord, PluralCategory, PluralLeaf } from '../types';
+import type { 
+    LinesRecord, 
+    PluralCategory, 
+    PluralLeaf, 
+    PluralLeafExplicit, 
+} from '../types';
+
+export const PLURAL_MARKER = '@plural';
 
 const PLURAL_CATEGORIES = new Set<PluralCategory>([
-    'zero', 
-    'one', 
-    'two', 
-    'few', 
-    'many', 
+    'zero',
+    'one',
+    'two',
+    'few',
+    'many',
     'other',
 ]);
 
+/**
+ * Detects a bare `{ one, other, ... }` plural object by structure. Returns
+ * `true` only when every key is a CLDR category and `other` is present.
+ */
 export function isPluralLeaf(value: unknown): value is PluralLeaf {
     if (!isObject(value)) {
         return false;
@@ -37,12 +48,38 @@ export function isPluralLeaf(value: unknown): value is PluralLeaf {
     return true;
 }
 
+/**
+ * Detects an explicit `{ "@plural": { ... } }` wrapper. Recommended form —
+ * unambiguous regardless of sibling key names.
+ */
+export function isPluralLeafExplicit(value: unknown): value is PluralLeafExplicit {
+    if (!isObject(value)) {
+        return false;
+    }
+    const obj = value as Record<string, unknown>;
+    return PLURAL_MARKER in obj && isPluralLeaf(obj[PLURAL_MARKER]);
+}
+
+/**
+ * Unwrap either plural form (explicit or structural) into the inner
+ * `PluralLeaf`. Returns `undefined` for non-plural values.
+ */
+export function asPluralLeaf(value: unknown): PluralLeaf | undefined {
+    if (isPluralLeafExplicit(value)) {
+        return value[PLURAL_MARKER];
+    }
+    if (isPluralLeaf(value)) {
+        return value;
+    }
+    return undefined;
+}
+
 export function isLineRecord(value: unknown): value is LinesRecord {
     if (!isObject(value)) {
         return false;
     }
 
-    if (isPluralLeaf(value)) {
+    if (isPluralLeaf(value) || isPluralLeafExplicit(value)) {
         return false;
     }
 
@@ -53,6 +90,7 @@ export function isLineRecord(value: unknown): value is LinesRecord {
         if (
             typeof ob[key] !== 'string' &&
             !isPluralLeaf(ob[key]) &&
+            !isPluralLeafExplicit(ob[key]) &&
             !isLineRecord(ob[key])
         ) {
             return false;

--- a/packages/ilingo/src/utils/index.ts
+++ b/packages/ilingo/src/utils/index.ts
@@ -7,4 +7,5 @@
 
 export * from './identify';
 export * from './language';
+export * from './locale';
 export * from './template';

--- a/packages/ilingo/src/utils/locale.ts
+++ b/packages/ilingo/src/utils/locale.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Fallback } from '../types';
+
+/**
+ * Derive the BCP-47 parent tags of a locale, from most-specific to most-generic.
+ *
+ * `pt-BR-Latn` → `['pt-BR', 'pt']`
+ * `pt-BR`      → `['pt']`
+ * `pt`         → `[]`
+ */
+export function bcp47Parents(locale: string): string[] {
+    const parts = locale.split('-');
+    const chain: string[] = [];
+    for (let i = parts.length - 1; i > 0; i--) {
+        chain.push(parts.slice(0, i).join('-'));
+    }
+    return chain;
+}
+
+/**
+ * Resolve the ordered chain of locales to try for a single lookup.
+ *
+ * The returned array always starts with `locale` and ends with the default
+ * locale, deduplicated. The middle is the explicit `fallback` if given,
+ * otherwise the BCP-47 parent chain.
+ */
+export function resolveLocaleChain(
+    locale: string,
+    fallback: Fallback | undefined,
+    defaultLocale: string,
+): string[] {
+    const explicit: string[] = [];
+
+    if (typeof fallback === 'function') {
+        explicit.push(...fallback(locale));
+    } else if (Array.isArray(fallback)) {
+        explicit.push(...fallback);
+    } else if (typeof fallback === 'string') {
+        explicit.push(fallback);
+    } else {
+        explicit.push(...bcp47Parents(locale));
+    }
+
+    const chain = [locale, ...explicit, defaultLocale];
+    return Array.from(new Set(chain));
+}

--- a/packages/ilingo/src/utils/locale.ts
+++ b/packages/ilingo/src/utils/locale.ts
@@ -35,6 +35,11 @@ export function resolveLocaleChain(
     fallback: Fallback | undefined,
     defaultLocale: string,
 ): string[] {
+    // Opt out of fallback entirely — chain is just the requested locale.
+    if (fallback === false) {
+        return [locale];
+    }
+
     const explicit: string[] = [];
 
     if (typeof fallback === 'function') {
@@ -47,6 +52,17 @@ export function resolveLocaleChain(
         explicit.push(...bcp47Parents(locale));
     }
 
-    const chain = [locale, ...explicit, defaultLocale];
-    return Array.from(new Set(chain));
+    // Order-preserving de-dupe that guarantees defaultLocale stays at the end.
+    // A plain `new Set([...locale, ...explicit, defaultLocale])` would move
+    // defaultLocale earlier in the chain if it appears in `explicit`.
+    const seen = new Set<string>();
+    const chain: string[] = [];
+    for (const candidate of [locale, ...explicit]) {
+        if (candidate !== defaultLocale && !seen.has(candidate)) {
+            seen.add(candidate);
+            chain.push(candidate);
+        }
+    }
+    chain.push(defaultLocale);
+    return chain;
 }

--- a/packages/ilingo/src/utils/locale.ts
+++ b/packages/ilingo/src/utils/locale.ts
@@ -41,15 +41,25 @@ export function resolveLocaleChain(
     }
 
     const explicit: string[] = [];
+    // Did the caller hand us an *explicit* fallback shape (array or function)?
+    // If yes and that shape evaluates to empty, the caller is asking for no
+    // fallback at all — don't fall back to the default locale either.
+    let explicitlyProvided = false;
 
     if (typeof fallback === 'function') {
+        explicitlyProvided = true;
         explicit.push(...fallback(locale));
     } else if (Array.isArray(fallback)) {
+        explicitlyProvided = true;
         explicit.push(...fallback);
     } else if (typeof fallback === 'string') {
         explicit.push(fallback);
     } else {
         explicit.push(...bcp47Parents(locale));
+    }
+
+    if (explicitlyProvided && explicit.length === 0) {
+        return [locale];
     }
 
     // Order-preserving de-dupe that guarantees defaultLocale stays at the end.

--- a/packages/ilingo/test/unit/resolution.spec.ts
+++ b/packages/ilingo/test/unit/resolution.spec.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Ilingo, MemoryStore } from '../../src';
+
+describe('Ilingo — resolution path', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warn.mockRestore();
+    });
+
+    describe('#895 — pluralization', () => {
+        const make = () => new Ilingo({
+            store: new MemoryStore({
+                data: {
+                    en: {
+                        cart: {
+                            items: {
+                                one: '{{count}} item',
+                                other: '{{count}} items',
+                            },
+                        },
+                    },
+                    cy: {
+                        cart: {
+                            items: {
+                                zero: 'dim eitemau',
+                                one: '{{count}} eitem',
+                                two: '{{count}} eitem',
+                                few: '{{count}} eitem',
+                                many: '{{count}} eitem',
+                                other: '{{count}} eitem',
+                            },
+                        },
+                    },
+                },
+            }),
+        });
+
+        it('selects "one" for count === 1', async () => {
+            expect(
+                await make().get({ group: 'cart', key: 'items', count: 1 }),
+            ).toEqual('1 item');
+        });
+
+        it('selects "other" for count === 0 in English', async () => {
+            expect(
+                await make().get({ group: 'cart', key: 'items', count: 0 }),
+            ).toEqual('0 items');
+        });
+
+        it('selects "zero" in Welsh', async () => {
+            expect(
+                await make().get({
+                    group: 'cart', key: 'items', count: 0, locale: 'cy',
+                }),
+            ).toEqual('dim eitemau');
+        });
+
+        it('falls back to "other" if the selected category is absent', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: { en: { cart: { items: { other: '{{count}} items' } } } },
+                }),
+            });
+            expect(
+                await ilingo.get({ group: 'cart', key: 'items', count: 1 }),
+            ).toEqual('1 items');
+        });
+
+        it('returns the plain string when count is omitted on a plural leaf', async () => {
+            // Documented behaviour: without count, default to `other`.
+            expect(
+                await make().get({ group: 'cart', key: 'items' }),
+            ).toEqual('{{count}} items');
+        });
+
+        it('count merges into data without overriding an explicit value', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        en: {
+                            cart: {
+                                items: {
+                                    one: '{{count}} of {{total}}',
+                                    other: '{{count}} of {{total}}',
+                                },
+                            },
+                        },
+                    },
+                }),
+            });
+            expect(
+                await ilingo.get({
+                    group: 'cart',
+                    key: 'items',
+                    count: 3,
+                    data: { total: 99 },
+                }),
+            ).toEqual('3 of 99');
+        });
+    });
+
+    describe('#897 — fallback locale chain', () => {
+        it('derives BCP-47 parents by default', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        pt: { app: { hi: 'olá pt' } },
+                        'pt-BR': { app: {} },
+                    },
+                }),
+                locale: 'pt-BR',
+            });
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('olá pt');
+        });
+
+        it('falls all the way to LOCALE_DEFAULT', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: { en: { app: { hi: 'hello' } } },
+                }),
+                locale: 'pt-BR',
+            });
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('hello');
+        });
+
+        it('respects an explicit string fallback', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: { es: { app: { hi: 'hola' } } },
+                }),
+                locale: 'pt-BR',
+                fallback: 'es',
+            });
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('hola');
+        });
+
+        it('respects an explicit fallback array, in order', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        fr: { app: { hi: 'salut' } },
+                        es: { app: { hi: 'hola' } },
+                    },
+                }),
+                locale: 'pt-BR',
+                fallback: ['es', 'fr'],
+            });
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('hola');
+        });
+
+        it('respects a fallback resolver function', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: { fr: { app: { hi: 'salut' } } },
+                }),
+                locale: 'pt-BR',
+                fallback: (locale) => (locale.startsWith('pt') ? ['fr'] : []),
+            });
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('salut');
+        });
+
+        it('getResolvedLocale reports which locale yielded the value', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        pt: { app: { hi: 'olá pt' } },
+                    },
+                }),
+                locale: 'pt-BR',
+            });
+            expect(
+                await ilingo.getResolvedLocale({ group: 'app', key: 'hi' }),
+            ).toEqual('pt');
+            expect(
+                await ilingo.getResolvedLocale({ group: 'app', key: 'missing' }),
+            ).toBeUndefined();
+        });
+
+        it('locale-closeness beats store priority', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: { en: { app: { hi: 'hello (store1)' } } },
+                }),
+                locale: 'pt-BR',
+            });
+            ilingo.stores.add(new MemoryStore({
+                data: { pt: { app: { hi: 'olá (store2)' } } },
+            }));
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('olá (store2)');
+        });
+    });
+
+    describe('#899 — missing-key handler', () => {
+        it('default handler warns once per (locale, group, key) and returns undefined', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({ data: {} }),
+            });
+
+            expect(await ilingo.get({ group: 'app', key: 'nope' })).toBeUndefined();
+            expect(await ilingo.get({ group: 'app', key: 'nope' })).toBeUndefined();
+
+            expect(warn).toHaveBeenCalledTimes(1);
+            expect(warn.mock.calls[0][0]).toContain('app.nope');
+        });
+
+        it('custom handler may return a string, which becomes the result', async () => {
+            const onMissingKey = vi.fn(() => 'FALLBACK');
+            const ilingo = new Ilingo({
+                store: new MemoryStore({ data: {} }),
+                onMissingKey,
+            });
+
+            expect(await ilingo.get({ group: 'app', key: 'nope' })).toEqual('FALLBACK');
+            expect(onMissingKey).toHaveBeenCalledWith(
+                expect.objectContaining({ group: 'app', key: 'nope' }),
+            );
+        });
+
+        it('handler receives resolvedLocale = last locale in the chain', async () => {
+            const onMissingKey = vi.fn(() => undefined);
+            const ilingo = new Ilingo({
+                store: new MemoryStore({ data: {} }),
+                locale: 'pt-BR',
+                onMissingKey,
+            });
+
+            await ilingo.get({ group: 'app', key: 'nope' });
+
+            expect(onMissingKey).toHaveBeenCalledWith(
+                expect.objectContaining({ resolvedLocale: 'en' }),
+            );
+        });
+
+        it('handler is not called when a hit is found', async () => {
+            const onMissingKey = vi.fn();
+            const ilingo = new Ilingo({
+                store: new MemoryStore({ data: { en: { app: { hi: 'hello' } } } }),
+                onMissingKey,
+            });
+            await ilingo.get({ group: 'app', key: 'hi' });
+            expect(onMissingKey).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/ilingo/test/unit/resolution.spec.ts
+++ b/packages/ilingo/test/unit/resolution.spec.ts
@@ -285,4 +285,97 @@ describe('Ilingo — resolution path', () => {
             ).toEqual('7 items');
         });
     });
+
+    describe('explicit @plural marker', () => {
+        it('recognises { "@plural": { ... } } as a plural leaf', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        en: {
+                            cart: {
+                                items: {
+                                    '@plural': {
+                                        one: '{{count}} item',
+                                        other: '{{count}} items',
+                                    },
+                                },
+                            },
+                        },
+                    },
+                }),
+            });
+            expect(
+                await ilingo.get({ group: 'cart', key: 'items', count: 1 }),
+            ).toEqual('1 item');
+            expect(
+                await ilingo.get({ group: 'cart', key: 'items', count: 3 }),
+            ).toEqual('3 items');
+        });
+
+        it('disambiguates a namespace whose only key happens to be "other"', async () => {
+            // Without the explicit marker, { other: 'literal' } would be
+            // detected as a plural leaf and `.deeper` would fail. With the
+            // marker, `other` is just a regular nested record.
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        en: {
+                            form: {
+                                kind: {
+                                    other: { label: 'Other' },
+                                },
+                            },
+                        },
+                    },
+                }),
+            });
+            expect(
+                await ilingo.get({ group: 'form', key: 'kind.other.label' }),
+            ).toEqual('Other');
+        });
+    });
+
+    describe('parallel lookup', () => {
+        it('queries every store in a locale concurrently, not serially', async () => {
+            // Record when each store's get() actually runs. Concurrent entry
+            // means both stores start in the same microtask burst — well
+            // before the 30ms simulated work has resolved. Asserting on
+            // entry order (not total elapsed time) avoids CI-jitter flakes.
+            const entries: { id: number, at: number }[] = [];
+            const makeStore = (id: number, hit?: string) => ({
+                async get(_ctx: { locale: string; group: string; key: string }) {
+                    entries.push({ id, at: Date.now() });
+                    await new Promise((r) => setTimeout(r, 30));
+                    return hit;
+                },
+                async set() { /* noop */ },
+                async getLocales() { return []; },
+            });
+
+            const ilingo = new Ilingo({});
+            ilingo.stores.add(makeStore(1));
+            ilingo.stores.add(makeStore(2, 'hello'));
+
+            const result = await ilingo.get({ group: 'app', key: 'hi' });
+
+            expect(result).toEqual('hello');
+            expect(entries.map((e) => e.id)).toEqual([1, 2]);
+            // Both stores entered well within one tick — far less than the
+            // 30ms a sequential walk would have inserted between them.
+            expect(entries[1].at - entries[0].at).toBeLessThan(15);
+        });
+
+        it('preserves store insertion order on a tie within a locale', async () => {
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: { en: { app: { hi: 'from store 1' } } },
+                }),
+            });
+            ilingo.stores.add(new MemoryStore({
+                data: { en: { app: { hi: 'from store 2' } } },
+            }));
+
+            expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('from store 1');
+        });
+    });
 });

--- a/packages/ilingo/test/unit/resolution.spec.ts
+++ b/packages/ilingo/test/unit/resolution.spec.ts
@@ -252,5 +252,37 @@ describe('Ilingo — resolution path', () => {
             await ilingo.get({ group: 'app', key: 'hi' });
             expect(onMissingKey).not.toHaveBeenCalled();
         });
+
+        it('warn-once state is per-instance, not shared across Ilingo instances', async () => {
+            const a = new Ilingo({ store: new MemoryStore({ data: {} }) });
+            const b = new Ilingo({ store: new MemoryStore({ data: {} }) });
+
+            await a.get({ group: 'app', key: 'isolated' });
+            await b.get({ group: 'app', key: 'isolated' });
+
+            // Two instances → two warnings for the same key. Without
+            // per-instance state, `b` would silently dedupe `a`'s warning.
+            expect(warn).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('plural-leaf write side (#912 review)', () => {
+        it('MemoryStore.set + get round-trips a plural leaf', async () => {
+            const store = new MemoryStore({ data: {} });
+            await store.set({
+                locale: 'en',
+                group: 'cart',
+                key: 'items',
+                value: { one: '{{count}} item', other: '{{count}} items' },
+            });
+
+            const ilingo = new Ilingo({ store });
+            expect(
+                await ilingo.get({ group: 'cart', key: 'items', count: 1 }),
+            ).toEqual('1 item');
+            expect(
+                await ilingo.get({ group: 'cart', key: 'items', count: 7 }),
+            ).toEqual('7 items');
+        });
     });
 });

--- a/packages/ilingo/test/unit/utils/locale.spec.ts
+++ b/packages/ilingo/test/unit/utils/locale.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { bcp47Parents, resolveLocaleChain } from '../../../src/utils/locale';
+
+describe('utils/locale', () => {
+    it('derives BCP-47 parents from most specific to most generic', () => {
+        expect(bcp47Parents('pt-BR-Latn')).toEqual(['pt-BR', 'pt']);
+        expect(bcp47Parents('pt-BR')).toEqual(['pt']);
+        expect(bcp47Parents('pt')).toEqual([]);
+    });
+
+    it('falls back to BCP-47 parents when no explicit fallback is configured', () => {
+        expect(resolveLocaleChain('pt-BR', undefined, 'en')).toEqual([
+            'pt-BR', 'pt', 'en',
+        ]);
+    });
+
+    it('accepts a single fallback string', () => {
+        expect(resolveLocaleChain('pt-BR', 'es', 'en')).toEqual([
+            'pt-BR', 'es', 'en',
+        ]);
+    });
+
+    it('accepts a fallback array in declared order', () => {
+        expect(resolveLocaleChain('pt-BR', ['es', 'fr'], 'en')).toEqual([
+            'pt-BR', 'es', 'fr', 'en',
+        ]);
+    });
+
+    it('accepts a fallback resolver function', () => {
+        expect(
+            resolveLocaleChain(
+                'pt-BR',
+                (locale) => [locale.toLowerCase()],
+                'en',
+            ),
+        ).toEqual(['pt-BR', 'pt-br', 'en']);
+    });
+
+    it('deduplicates the chain', () => {
+        expect(resolveLocaleChain('en', undefined, 'en')).toEqual(['en']);
+        expect(resolveLocaleChain('en', 'en', 'en')).toEqual(['en']);
+    });
+});

--- a/packages/ilingo/test/unit/utils/locale.spec.ts
+++ b/packages/ilingo/test/unit/utils/locale.spec.ts
@@ -60,4 +60,18 @@ describe('utils/locale', () => {
         expect(resolveLocaleChain('ru', false, 'en')).toEqual(['ru']);
         expect(resolveLocaleChain('pt-BR', false, 'en')).toEqual(['pt-BR']);
     });
+
+    it('explicit empty array also opts out (default locale not appended)', () => {
+        // Two independent reviewers expected `fallback: []` to mean "no
+        // fallback at all". Treat literal-empty explicit shapes as opt-out
+        // so the API matches that intuition.
+        expect(resolveLocaleChain('ru', [], 'en')).toEqual(['ru']);
+        expect(resolveLocaleChain('pt-BR', [], 'en')).toEqual(['pt-BR']);
+    });
+
+    it('resolver function returning [] also opts out', () => {
+        expect(
+            resolveLocaleChain('ru', () => [], 'en'),
+        ).toEqual(['ru']);
+    });
 });

--- a/packages/ilingo/test/unit/utils/locale.spec.ts
+++ b/packages/ilingo/test/unit/utils/locale.spec.ts
@@ -47,4 +47,17 @@ describe('utils/locale', () => {
         expect(resolveLocaleChain('en', undefined, 'en')).toEqual(['en']);
         expect(resolveLocaleChain('en', 'en', 'en')).toEqual(['en']);
     });
+
+    it('keeps defaultLocale at the terminal position even when it appears earlier in fallback', () => {
+        // Regression for #912 review: prior `new Set(...)` would yield
+        // ['pt-BR', 'en', 'fr'] because Set preserves insertion order.
+        expect(resolveLocaleChain('pt-BR', ['en', 'fr'], 'en')).toEqual([
+            'pt-BR', 'fr', 'en',
+        ]);
+    });
+
+    it('fallback: false opts out entirely — chain is just [locale]', () => {
+        expect(resolveLocaleChain('ru', false, 'en')).toEqual(['ru']);
+        expect(resolveLocaleChain('pt-BR', false, 'en')).toEqual(['pt-BR']);
+    });
 });

--- a/packages/vue/src/composables/use-translation.ts
+++ b/packages/vue/src/composables/use-translation.ts
@@ -7,6 +7,7 @@
 
 import { computedAsync } from '@vueuse/core';
 import type { Ref } from 'vue';
+import { unref } from 'vue';
 import type { GetContextReactive } from '../types';
 import { extractReactiveData } from './utils';
 import { injectIlingo } from './instance';
@@ -29,7 +30,7 @@ export function useTranslation(ctx: GetContextReactive): Ref<string> {
                     undefined,
                 group: ctx.group,
                 key: ctx.key,
-                count: ctx.count,
+                count: typeof ctx.count === 'undefined' ? undefined : unref(ctx.count),
             });
 
             return value || defaultValue;

--- a/packages/vue/src/composables/use-translation.ts
+++ b/packages/vue/src/composables/use-translation.ts
@@ -12,7 +12,7 @@ import { extractReactiveData } from './utils';
 import { injectIlingo } from './instance';
 import { injectLocale } from './locale';
 
-export function useTranslation(ctx: GetContextReactive) : Ref<string> {
+export function useTranslation(ctx: GetContextReactive): Ref<string> {
     const instance = injectIlingo();
     const locale = injectLocale();
 
@@ -29,6 +29,7 @@ export function useTranslation(ctx: GetContextReactive) : Ref<string> {
                     undefined,
                 group: ctx.group,
                 key: ctx.key,
+                count: ctx.count,
             });
 
             return value || defaultValue;

--- a/packages/vue/src/composables/use-translation.ts
+++ b/packages/vue/src/composables/use-translation.ts
@@ -30,7 +30,7 @@ export function useTranslation(ctx: GetContextReactive): Ref<string> {
                     undefined,
                 group: ctx.group,
                 key: ctx.key,
-                count: typeof ctx.count === 'undefined' ? undefined : unref(ctx.count),
+                count: unref(ctx.count),
             });
 
             return value || defaultValue;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -15,6 +15,7 @@ export type Options = {
 
 export type DataMaybeRef = Record<string, MaybeRef<string | number>>;
 
-export type GetContextReactive = Omit<GetContext, 'data'> & {
-    data?: DataMaybeRef
+export type GetContextReactive = Omit<GetContext, 'data' | 'count'> & {
+    data?: DataMaybeRef,
+    count?: MaybeRef<number>,
 };


### PR DESCRIPTION
## Summary

Implements **phase 2** of the roadmap ([.agents/plans/002-resolution-path.md](.agents/plans/002-resolution-path.md)). Closes #895, #897, #899; advances the [#907](https://github.com/tada5hi/ilingo/issues/907) umbrella.

The three features all touch `Ilingo.get()` and share test scaffolding, so they land in one PR per the umbrella's sequencing guidance.

### #895 — Pluralization via \`Intl.PluralRules\`

\`LinesRecord\` leaves may now be \`{ zero?, one?, two?, few?, many?, other }\` plural objects. The matching CLDR category is selected against the new \`count\` field on \`GetContext\`, with \`other\` as the documented fallback. \`count\` is auto-merged into \`data\` so \`{{count}}\` works without restating it (explicit \`data.count\` still wins).

\`\`\`ts
await ilingo.get({ group: 'cart', key: 'items', count: 1 });   // "1 item"
await ilingo.get({ group: 'cart', key: 'items', count: 5 });   // "5 items"
\`\`\`

### #897 — Region-aware fallback locale chain

\`Config.fallback\` accepts \`string | string[] | (locale) => string[]\`. Default derives BCP-47 parents and always terminates at \`LOCALE_DEFAULT\`. The chain is walked **locale-first** across all stores — closest locale wins regardless of store order. New introspection methods: \`getResolvedLocaleChain(ctx)\`, \`getResolvedLocale(ctx)\`.

\`\`\`ts
new Ilingo({ locale: 'pt-BR' }).getResolvedLocaleChain({ locale: 'pt-BR' });
// ['pt-BR', 'pt', 'en']
\`\`\`

### #899 — Missing-key handler

\`Config.onMissingKey\` lets consumers override the dev-mode warning and optionally substitute a string for the result of \`get()\`. Default handler warns once per \`(locale, group, key)\` per process; silent in \`NODE_ENV=production\`. The Vue composable's display fallback is now overridable globally at the \`Ilingo\` instance.

## Breaking change

\`get({ locale: 'X' })\` for an \`X\` with no data now falls through to the default locale instead of returning \`undefined\`. Pass \`fallback: []\` to opt out, or pre-check via \`getResolvedLocale\`. One pre-existing fs test was updated to reflect this.

## Test plan

- [x] \`npm run build\` (4 workspaces)
- [x] \`npm run lint\` (clean)
- [x] \`npm run test\` — 42 tests pass (32 ilingo + 10 fs); 19 are new
- [x] Plural selection verified in English (\`one\`/\`other\`) and Welsh (six categories)
- [x] Fallback chain tested for all four shapes (default BCP-47, string, array, function)
- [x] Missing-key handler tested for default warn-once, custom string return, \`resolvedLocale\` propagation
- [x] Locale-closeness-beats-store-priority guard test

## Roadmap

After merging:

- [Phase 3 — Intl formatters (#896)](.agents/plans/003-intl-formatters.md) becomes Ready.
- [Phase 4 — Type-safe keys (#898)](.agents/plans/004-type-safe-keys.md) becomes Ready (parallelizable with Phase 3).
- [Phase 5 — Vue ergonomics (#900, #901, #902)](.agents/plans/005-vue-ergonomics.md) becomes Ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluralization support (CLDR/Intl.PluralRules) and plural-aware translation values
  * Customizable locale-fallback chains with BCP‑47 parent defaults and opt-out
  * Configurable missing-key handling with production-aware warn behavior
  * Public methods to inspect resolved locale(s) and the locale that produced a value
  * Vue composable now forwards reactive count for correct plural lookups

* **Documentation**
  * Expanded usage guide covering pluralization, fallback chains, and missing-key handling

* **Tests**
  * Added comprehensive tests for resolution path, plural leaves, and locale-chain behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/ilingo/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->