### PR TITLE
feat(ilingo): intl number/date/list formatters in templates

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -37,7 +37,17 @@ A leaf can be either a plain `string` or a `PluralLeaf` (`{ zero?, one?, two?, f
 
 The orchestrator selects a form using `Intl.PluralRules` keyed by the *resolved* locale (the one that actually matched). `Intl.PluralRules` instances are cached per locale on the `Ilingo` instance.
 
-### 6. ESM-first, dependency-light, browser-safe
+### 6. Template formatters via a per-instance registry
+
+Template placeholders accept modifier syntax: `{{value, formatter}}` and `{{value, formatter(opt=value, ...)}}`. The orchestrator owns a `FormatterRegistry` instance that:
+
+- Holds the built-in formatters `number`, `date`, `list` (backed by `Intl.NumberFormat` / `Intl.DateTimeFormat` / `Intl.ListFormat`).
+- Memoises `Intl.*Format` instances keyed by `(formatter, locale, JSON-encoded options)` so repeated renders don't reallocate.
+- Exposes `register(name, fn)` and `get(name)` — designed so Phase 6 (#906) opens it to user-supplied formatters without re-architecting.
+
+The locale handed to a formatter is the **resolved** locale (the one that actually yielded the message), not the requested one. Unknown modifiers fall back to `String(value)` and emit a per-instance dev-mode one-shot warning via the same `isProductionEnv()` gate used by the missing-key handler.
+
+### 7. ESM-first, dependency-light, browser-safe
 
 Each package's runtime dependencies are minimal — `pathtrace` and `smob` in core; `locter`, `pathe`, `smob` in `@ilingo/fs`. Vue and Vuelidate are declared as `peerDependencies`, not bundled. Core does not import `node:process` — `NODE_ENV` is read via a bare `process.env.NODE_ENV` literal (so Vite / Webpack DefinePlugin can replace it) wrapped in a `typeof process !== 'undefined'` guard for raw-browser execution.
 
@@ -106,7 +116,7 @@ protected async lookup(chain, ctx) {
 }
 ```
 
-`Ilingo` owns: the locale (default `'en'` from `LOCALE_DEFAULT`), the ordered store set, the fallback config, the missing-key handler, a per-instance `pluralRulesCache: Map<string, Intl.PluralRules>`, a per-instance `warnedKeys: Set<string>` for the default warn-once handler, and the `{{var}}` template formatter. Framework-specific concerns live in higher-layer packages.
+`Ilingo` owns: the locale (default `'en'` from `LOCALE_DEFAULT`), the ordered store set, the fallback config, the missing-key handler, a per-instance `pluralRulesCache: Map<string, Intl.PluralRules>`, a per-instance `formatters: FormatterRegistry` (with its own `Intl.*Format` cache), a per-instance `warnedKeys` / `warnedFormatters: Set<string>` for the two warn-once channels, and the `{{var}}` template formatter. Framework-specific concerns live in higher-layer packages.
 
 ### Missing-key handler
 
@@ -145,7 +155,8 @@ Processing:
   5. selectPluralForm(leaf, hitLocale, count)
        └── Intl.PluralRules(hitLocale) [cached] selects category, falls back to 'other'
   6. count auto-merges into data if absent
-  7. template(message, data) substitutes {{var}} placeholders
+  7. template(message, data, { locale: hitLocale, formatters }) substitutes
+     {{var}} and {{var, formatter(opts)}} placeholders
 
 Output:
   └── Promise<string | undefined>     ('undefined' = handler returned no string)
@@ -168,7 +179,8 @@ packages/ilingo/src/
 ├── utils/
 │   ├── locale.ts            ← bcp47Parents, resolveLocaleChain
 │   ├── identify.ts          ← isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord, PLURAL_MARKER
-│   ├── template.ts          ← {{var}} substitution
+│   ├── formatters.ts        ← FormatterRegistry, parseFormatterOptions, parseModifier, Formatter type
+│   ├── template.ts          ← {{var}} + {{var, formatter(opts)}} substitution
 │   └── language/            ← isBCP47LanguageCode + CLDR data
 └── config/                  ← typed input shape
 

--- a/.agents/plans/003-intl-formatters.md
+++ b/.agents/plans/003-intl-formatters.md
@@ -1,6 +1,6 @@
 # Phase 3 — Intl formatters
 
-**Status**: Blocked by Phase 2 (shares the `GetContext` shape).
+**Status**: In review (branch `feat/intl-formatters`).
 **Tracks**: [#896](https://github.com/tada5hi/ilingo/issues/896).
 
 Add `Intl.NumberFormat`, `Intl.DateTimeFormat`, and `Intl.ListFormat` support to the template formatter so consumers don't have to pre-format values in calling code.
@@ -22,9 +22,10 @@ Add `Intl.NumberFormat`, `Intl.DateTimeFormat`, and `Intl.ListFormat` support to
 
 ## Acceptance
 
-- [ ] `"You owe {{amount, number(currency=EUR, style=currency)}}"` renders correctly for `en` and `de`.
-- [ ] Unknown modifier falls back to the raw value (no throw) and emits a dev-only warning routed through `onMissingKey`'s sibling diagnostic channel.
-- [ ] Formatter cache lives on the `Ilingo` instance — verified by spying construction count across repeated renders.
+- [x] `"You owe {{amount, number(currency=EUR, style=currency)}}"` renders correctly for `en` and `de` (resolved-locale propagation tested).
+- [x] Unknown modifier falls back to the raw value (no throw) and emits a per-instance dev-only warn-once via `Ilingo.handleUnknownFormatter` (mirrors the missing-key diagnostic shape). Production is silenced via the same `isProductionEnv()` gate.
+- [x] Formatter cache lives on the `Ilingo` instance — asserted by reading the registry's `cache.size` after repeated renders.
+- [x] Tightened modifier parser rejects malformed names (`number)`, stray punctuation) instead of treating them as valid identifiers.
 
 ## Why now
 

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -6,7 +6,7 @@ Phased roadmap for ilingo, sequenced to land coherent waves of work rather than 
 |-------|---------------------------------------------------|-------------|---------------------------------|
 | 1     | [001-dependency-cleanup.md](001-dependency-cleanup.md) | Done        | Post-modernization hygiene      |
 | 2     | [002-resolution-path.md](002-resolution-path.md)       | In review   | #895, #897, #899                |
-| 3     | [003-intl-formatters.md](003-intl-formatters.md)       | Blocked by 2| #896                            |
+| 3     | [003-intl-formatters.md](003-intl-formatters.md)       | In review   | #896                            |
 | 4     | [004-type-safe-keys.md](004-type-safe-keys.md)         | Blocked by 2| #898                            |
 | 5     | [005-vue-ergonomics.md](005-vue-ergonomics.md)         | Blocked by 2| #900, #901, #902                |
 | 6     | [006-dx-and-loader.md](006-dx-and-loader.md)           | Blocked by 5| #903, #904, #905, #906          |

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -52,17 +52,20 @@ src/
     ├── index.ts
     ├── locale.ts             # bcp47Parents, resolveLocaleChain
     ├── identify.ts           # PLURAL_MARKER + isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord
-    ├── template.ts           # {{var}} interpolation
+    ├── formatters.ts         # FormatterRegistry, parseFormatterOptions, parseModifier, Formatter type
+    ├── template.ts           # {{var}} + {{var, formatter(opts)}} interpolation
     └── language/
         ├── index.ts
         ├── module.ts         # isBCP47LanguageCode
         └── data.json         # BCP-47 language code table
 test/
 └── unit/
-    ├── module.spec.ts        # legacy core behaviour
-    ├── resolution.spec.ts    # plural, fallback chain, missing-key handler, parallel lookup
+    ├── module.spec.ts                # legacy core behaviour
+    ├── resolution.spec.ts            # plural, fallback chain, missing-key handler, parallel lookup
+    ├── formatters-integration.spec.ts # Ilingo.get() with number/date/list modifiers, cache + dev-warn
     └── utils/
-        ├── locale.spec.ts    # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
+        ├── locale.spec.ts            # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
+        ├── formatters.spec.ts        # parseFormatterOptions, parseModifier, FormatterRegistry, template dispatch
         ├── identify.spec.ts
         └── template.spec.ts
 ```

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -27,14 +27,18 @@ Nx caches `test` (see `nx.json` → `cacheableOperations`). To re-run an already
 
 ```
 unit/
-├── module.spec.ts              # legacy core behaviour — get/set, locale switching, merge()
-├── resolution.spec.ts          # pluralization (incl. explicit @plural form), fallback chain
-│                               #   (default, string, array, function, false, []), missing-key handler,
-│                               #   per-instance warn isolation, parallel intra-locale lookup
+├── module.spec.ts                  # legacy core behaviour — get/set, locale switching, merge()
+├── resolution.spec.ts              # pluralization (incl. explicit @plural form), fallback chain
+│                                   #   (default, string, array, function, false, []), missing-key
+│                                   #   handler, per-instance warn isolation, parallel intra-locale lookup
+├── formatters-integration.spec.ts  # end-to-end Ilingo.get() with number/date/list modifiers,
+│                                   #   resolved-locale propagation, per-instance cache, dev-warn
 └── utils/
-    ├── identify.spec.ts        # isLineRecord / isPluralLeaf / isPluralLeafExplicit
-    ├── locale.spec.ts          # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
-    └── template.spec.ts        # {{var}} interpolation
+    ├── identify.spec.ts            # isLineRecord / isPluralLeaf / isPluralLeafExplicit
+    ├── locale.spec.ts              # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
+    ├── formatters.spec.ts          # parseFormatterOptions, parseModifier, FormatterRegistry,
+    │                               #   template-level modifier dispatch
+    └── template.spec.ts            # {{var}} interpolation
 data/
 └── language/{en,de,fr}/form.{js,ts,json}   # cross-extension loader fixtures
 ```

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -392,7 +392,7 @@ await ilingo.get({ group: 'app', key: 'invited', data: { people: ['Alice', 'Bob'
 
 Syntax:
 
-```
+```text
 {{value}}                          plain substitution
 {{value, formatter}}               formatter with no options
 {{value, formatter(k=v, k2=v2)}}   formatter with options

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -21,6 +21,7 @@ Ilingo is a lightweight library for translation and internationalization.
   - [Pluralization](#pluralization)
   - [Fallback locale chain](#fallback-locale-chain)
   - [Missing-key handler](#missing-key-handler)
+  - [Formatters](#formatters)
 - [Store](#store)
   - [Memory](#memory-store)
   - [FileSystem](#fs-store)
@@ -363,6 +364,45 @@ const ilingo = new Ilingo({
     },
 });
 ```
+
+### Formatters
+
+Template placeholders support modifiers backed by `Intl.NumberFormat`, `Intl.DateTimeFormat`, and `Intl.ListFormat`:
+
+```typescript
+const ilingo = new Ilingo({
+    store: new MemoryStore({
+        data: {
+            en: {
+                app: {
+                    owe: 'You owe {{amount, number(style=currency, currency=EUR)}}',
+                    signed: 'Signed {{date, date(dateStyle=medium, timeZone=UTC)}}',
+                    invited: '{{people, list(style=long, type=conjunction)}}',
+                },
+            },
+        },
+    }),
+});
+
+await ilingo.get({ group: 'app', key: 'owe',     data: { amount: 99 } });           // "You owe €99.00"
+await ilingo.get({ group: 'app', key: 'signed',  data: { date: '2026-05-22T12:00:00Z' } }); // "Signed May 22, 2026"
+await ilingo.get({ group: 'app', key: 'invited', data: { people: ['Alice', 'Bob', 'Carol'] } });
+// → "Alice, Bob, and Carol"
+```
+
+Syntax:
+
+```
+{{value}}                          plain substitution
+{{value, formatter}}               formatter with no options
+{{value, formatter(k=v, k2=v2)}}   formatter with options
+```
+
+The locale used to construct the `Intl.*Format` instance is the **resolved** locale — the one that actually yielded the message via the fallback chain — not the requested one. `Intl.*Format` instances are memoised per `(formatter, locale, options)` on the `Ilingo` instance, so repeated renders do not reallocate.
+
+Option-value coercion: `42` → `42` (number), `true` / `false` → boolean, anything else → string. So `currency=EUR` becomes `{ currency: 'EUR' }`, `minimumFractionDigits=2` becomes `{ minimumFractionDigits: 2 }`.
+
+Unknown modifiers fall back to `String(value)` and emit a one-shot dev-mode warning (silenced in `process.env.NODE_ENV === 'production'`). Malformed modifier expressions (unbalanced parens, non-identifier names) are treated the same way — never throw.
 
 ## Store
 

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -281,7 +281,9 @@ export class Ilingo {
     /**
      * Substitute `{{var}}` placeholders. Modifier syntax
      * (`{{var, number(currency=EUR)}}`) is dispatched through
-     * `this.formatters` when `locale` is provided.
+     * `this.formatters`. The optional `locale` argument controls which
+     * locale `Intl.*Format` instances are constructed for; if omitted, the
+     * instance's current locale is used.
      */
     format(input: string, data: Record<string, any>, locale?: string): string {
         return template(input, data || {}, {

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -16,6 +16,7 @@ import type {
     MissingKeyHandler,
 } from './types';
 import {
+    FormatterRegistry,
     resolveLocaleChain,
     template,
 } from './utils';
@@ -52,12 +53,24 @@ export class Ilingo {
     protected pluralRulesCache: Map<string, Intl.PluralRules>;
 
     /**
+     * Per-instance registry for `{{value, formatter(opts)}}` template
+     * modifiers. Built-in entries: `number`, `date`, `list` (each backed
+     * by the matching `Intl.*Format`, memoised by `(locale, options)`).
+     */
+    public readonly formatters: FormatterRegistry;
+
+    /**
      * Per-instance set of `(locale, group, key)` triples that have already
      * triggered a missing-key warning. Kept on the instance — not module
      * scope — so multiple `Ilingo` instances do not dedupe each other's
      * warnings.
      */
     protected warnedKeys: Set<string>;
+
+    /**
+     * Mirror of `warnedKeys` for unknown-formatter diagnostics.
+     */
+    protected warnedFormatters: Set<string>;
 
     // ----------------------------------------------------
 
@@ -67,6 +80,8 @@ export class Ilingo {
         this.onMissingKey = input.onMissingKey;
         this.pluralRulesCache = new Map();
         this.warnedKeys = new Set();
+        this.warnedFormatters = new Set();
+        this.formatters = new FormatterRegistry();
 
         this.stores = new Set<IStore>();
         if (input.store) {
@@ -157,7 +172,7 @@ export class Ilingo {
         if (typeof ctx.count === 'number' && typeof data.count === 'undefined') {
             data.count = ctx.count;
         }
-        return this.format(message, data);
+        return this.format(message, data, hit.locale);
     }
 
     // ----------------------------------------------------
@@ -263,7 +278,25 @@ export class Ilingo {
 
     // ----------------------------------------------------
 
-    format(input: string, data: Record<string, any>) {
-        return template(input, data || {});
+    /**
+     * Substitute `{{var}}` placeholders. Modifier syntax
+     * (`{{var, number(currency=EUR)}}`) is dispatched through
+     * `this.formatters` when `locale` is provided.
+     */
+    format(input: string, data: Record<string, any>, locale?: string): string {
+        return template(input, data || {}, {
+            locale: locale ?? this.getLocale(),
+            formatters: this.formatters,
+            onUnknownFormatter: (name) => this.handleUnknownFormatter(name),
+        });
+    }
+
+    protected handleUnknownFormatter(name: string): void {
+        /* istanbul ignore next */
+        if (isProductionEnv()) return;
+        if (this.warnedFormatters.has(name)) return;
+        this.warnedFormatters.add(name);
+        // eslint-disable-next-line no-console
+        console.warn(`[ilingo] unknown formatter "${name}" — falling back to raw value`);
     }
 }

--- a/packages/ilingo/src/utils/formatters.ts
+++ b/packages/ilingo/src/utils/formatters.ts
@@ -67,10 +67,14 @@ export function parseModifier(input: string): { name: string, options: string | 
         // input like 'number)' that has no opening paren but a stray closing one.
         return NAME_RE.test(trimmed) ? { name: trimmed, options: undefined } : undefined;
     }
-    if (!trimmed.endsWith(')')) return undefined;
+    // The first `)` after the opening paren must be the very last character.
+    // Catches stray closes like `number(currency=EUR))` and nested parens
+    // (which the option grammar doesn't support).
+    const close = trimmed.indexOf(')', open);
+    if (close !== trimmed.length - 1) return undefined;
     const name = trimmed.slice(0, open).trim();
     if (!NAME_RE.test(name)) return undefined;
-    const options = trimmed.slice(open + 1, -1).trim();
+    const options = trimmed.slice(open + 1, close).trim();
     return { name, options };
 }
 
@@ -94,6 +98,7 @@ export class FormatterRegistry {
                 options,
                 () => new Intl.NumberFormat(locale, options as Intl.NumberFormatOptions),
             );
+            if (!fmt) return String(value);
             return fmt.format(numeric);
         });
 
@@ -113,6 +118,7 @@ export class FormatterRegistry {
                 options,
                 () => new Intl.DateTimeFormat(locale, options as Intl.DateTimeFormatOptions),
             );
+            if (!fmt) return String(value);
             return fmt.format(d);
         });
 
@@ -124,6 +130,7 @@ export class FormatterRegistry {
                 options,
                 () => new Intl.ListFormat(locale, options as Intl.ListFormatOptions),
             );
+            if (!fmt) return value.map(String).join(', ');
             return fmt.format(value.map(String));
         });
     }
@@ -140,16 +147,36 @@ export class FormatterRegistry {
         return this.entries.has(name);
     }
 
+    /**
+     * Look up or construct the `Intl.*Format` instance for `(kind, locale,
+     * options)`. Returns `undefined` if either the cache-key generation or
+     * the constructor throws — built-in formatters then fall back to a plain
+     * `String(value)` rendering rather than letting a typo in a translator's
+     * options crash the entire render.
+     *
+     * Options are stringified with sorted keys so callers that happen to pass
+     * the same logical options in a different order share a cache entry.
+     */
     protected intl<T extends Intl.NumberFormat | Intl.DateTimeFormat | Intl.ListFormat>(
         kind: string,
         locale: string,
         options: FormatterOptions,
         create: () => T,
-    ): T {
-        const key = `${kind}|${locale}|${JSON.stringify(options)}`;
+    ): T | undefined {
+        let key: string;
+        try {
+            const sortedKeys = Object.keys(options).sort();
+            key = `${kind}|${locale}|${JSON.stringify(options, sortedKeys)}`;
+        } catch {
+            return undefined;
+        }
         let fmt = this.cache.get(key) as T | undefined;
         if (!fmt) {
-            fmt = create();
+            try {
+                fmt = create();
+            } catch {
+                return undefined;
+            }
             this.cache.set(key, fmt);
         }
         return fmt;

--- a/packages/ilingo/src/utils/formatters.ts
+++ b/packages/ilingo/src/utils/formatters.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * A formatter receives the raw `data` value, parsed options from the
+ * placeholder, and the resolved locale. Return value is the substituted
+ * string. Internal contract — Phase 6 (#906) will expose this for user
+ * registration.
+ */
+export type Formatter = (
+    value: unknown,
+    options: Record<string, unknown>,
+    locale: string,
+) => string;
+
+export type FormatterOptions = Record<string, unknown>;
+
+/**
+ * Parse the options-string segment of a template modifier.
+ *
+ * `currency=EUR, style=currency, minimumFractionDigits=2`
+ *   → `{ currency: 'EUR', style: 'currency', minimumFractionDigits: 2 }`
+ *
+ * Numbers and booleans are auto-coerced; everything else stays a string.
+ */
+export function parseFormatterOptions(input: string | undefined): FormatterOptions {
+    if (!input) return {};
+    const result: FormatterOptions = {};
+    for (const segment of input.split(',')) {
+        const eq = segment.indexOf('=');
+        if (eq === -1) continue;
+        const key = segment.slice(0, eq).trim();
+        const rawValue = segment.slice(eq + 1).trim();
+        if (!key || !rawValue) continue;
+        if (rawValue === 'true') {
+            result[key] = true;
+        } else if (rawValue === 'false') {
+            result[key] = false;
+        } else if (/^-?\d+(\.\d+)?$/.test(rawValue)) {
+            result[key] = Number(rawValue);
+        } else {
+            result[key] = rawValue;
+        }
+    }
+    return result;
+}
+
+/**
+ * Split a modifier expression into `{ name, options }`.
+ * `number(currency=EUR)` → `{ name: 'number', options: 'currency=EUR' }`.
+ * `date`                  → `{ name: 'date', options: undefined }`.
+ *
+ * Returns `undefined` for malformed input (e.g. unbalanced parens).
+ */
+const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function parseModifier(input: string): { name: string, options: string | undefined } | undefined {
+    const trimmed = input.trim();
+    if (!trimmed) return undefined;
+    const open = trimmed.indexOf('(');
+    if (open === -1) {
+        // Bare name. Must be a valid identifier — guards against malformed
+        // input like 'number)' that has no opening paren but a stray closing one.
+        return NAME_RE.test(trimmed) ? { name: trimmed, options: undefined } : undefined;
+    }
+    if (!trimmed.endsWith(')')) return undefined;
+    const name = trimmed.slice(0, open).trim();
+    if (!NAME_RE.test(name)) return undefined;
+    const options = trimmed.slice(open + 1, -1).trim();
+    return { name, options };
+}
+
+/**
+ * Per-instance formatter registry. Caches `Intl.*Format` instances keyed by
+ * `(formatter, locale, JSON-encoded options)` so repeated template renders
+ * don't reallocate.
+ */
+export class FormatterRegistry {
+    protected entries = new Map<string, Formatter>();
+
+    protected cache = new Map<string, Intl.NumberFormat | Intl.DateTimeFormat | Intl.ListFormat>();
+
+    constructor() {
+        this.register('number', (value, options, locale) => {
+            const numeric = typeof value === 'number' ? value : Number(value);
+            if (Number.isNaN(numeric)) return String(value);
+            const fmt = this.intl<Intl.NumberFormat>(
+                'number', 
+                locale, 
+                options,
+                () => new Intl.NumberFormat(locale, options as Intl.NumberFormatOptions),
+            );
+            return fmt.format(numeric);
+        });
+
+        this.register('date', (value, options, locale) => {
+            let d: Date;
+            if (value instanceof Date) {
+                d = value;
+            } else if (typeof value === 'number' || typeof value === 'string') {
+                d = new Date(value);
+            } else {
+                return String(value);
+            }
+            if (Number.isNaN(d.getTime())) return String(value);
+            const fmt = this.intl<Intl.DateTimeFormat>(
+                'date', 
+                locale, 
+                options,
+                () => new Intl.DateTimeFormat(locale, options as Intl.DateTimeFormatOptions),
+            );
+            return fmt.format(d);
+        });
+
+        this.register('list', (value, options, locale) => {
+            if (!Array.isArray(value)) return String(value);
+            const fmt = this.intl<Intl.ListFormat>(
+                'list', 
+                locale, 
+                options,
+                () => new Intl.ListFormat(locale, options as Intl.ListFormatOptions),
+            );
+            return fmt.format(value.map(String));
+        });
+    }
+
+    register(name: string, formatter: Formatter): void {
+        this.entries.set(name, formatter);
+    }
+
+    get(name: string): Formatter | undefined {
+        return this.entries.get(name);
+    }
+
+    has(name: string): boolean {
+        return this.entries.has(name);
+    }
+
+    protected intl<T extends Intl.NumberFormat | Intl.DateTimeFormat | Intl.ListFormat>(
+        kind: string,
+        locale: string,
+        options: FormatterOptions,
+        create: () => T,
+    ): T {
+        const key = `${kind}|${locale}|${JSON.stringify(options)}`;
+        let fmt = this.cache.get(key) as T | undefined;
+        if (!fmt) {
+            fmt = create();
+            this.cache.set(key, fmt);
+        }
+        return fmt;
+    }
+}

--- a/packages/ilingo/src/utils/index.ts
+++ b/packages/ilingo/src/utils/index.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './formatters';
 export * from './identify';
 export * from './language';
 export * from './locale';

--- a/packages/ilingo/src/utils/template.ts
+++ b/packages/ilingo/src/utils/template.ts
@@ -14,6 +14,8 @@ export interface TemplateContext {
     onUnknownFormatter?: (name: string) => void;
 }
 
+const DEFAULT_REGEX = /\{\{\s*([^,}]+?)(?:\s*,\s*([^}]+?))?\s*\}\}/g;
+
 /**
  * Substitute `{{var}}` placeholders. With a `TemplateContext`, also supports
  * modifier syntax: `{{var, modifier}}` and `{{var, modifier(opts)}}`.
@@ -21,16 +23,27 @@ export interface TemplateContext {
  * - Unknown data key → placeholder left in place (unchanged from prior behaviour).
  * - Unknown modifier → raw value substituted, `onUnknownFormatter` invoked.
  * - Malformed modifier expression (e.g. unbalanced parens) → raw value substituted.
+ *
+ * The third parameter accepts either a `TemplateContext` (modern, with
+ * formatter support) or a `RegExp` (legacy escape-hatch for custom
+ * placeholder delimiters). Passing a `RegExp` disables modifier dispatch,
+ * matching the pre-formatter behaviour for callers that supplied their own
+ * delimiter.
  */
 export function template(
     str: string,
     data: Record<string, any>,
-    ctx?: TemplateContext,
+    ctxOrRegex?: TemplateContext | RegExp,
 ): string {
-    // Matches `{{var}}` and `{{var, modifierExpr}}`. The modifier capture
-    // allows commas inside parens (e.g. `list(style=long, type=conjunction)`)
-    // because `[^}]+?` is bounded only by the closing brace.
-    const regex = /\{\{\s*([^,}]+?)(?:\s*,\s*([^}]+?))?\s*\}\}/g;
+    let regex: RegExp;
+    let ctx: TemplateContext | undefined;
+    if (ctxOrRegex instanceof RegExp) {
+        regex = ctxOrRegex;
+        ctx = undefined;
+    } else {
+        regex = DEFAULT_REGEX;
+        ctx = ctxOrRegex;
+    }
 
     return str.replace(regex, (match, rawKey: string, modExpr: string | undefined) => {
         const key = rawKey.trim();

--- a/packages/ilingo/src/utils/template.ts
+++ b/packages/ilingo/src/utils/template.ts
@@ -5,20 +5,53 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { FormatterRegistry } from './formatters';
+import { parseFormatterOptions, parseModifier } from './formatters';
+
+export interface TemplateContext {
+    locale: string;
+    formatters: FormatterRegistry;
+    onUnknownFormatter?: (name: string) => void;
+}
+
+/**
+ * Substitute `{{var}}` placeholders. With a `TemplateContext`, also supports
+ * modifier syntax: `{{var, modifier}}` and `{{var, modifier(opts)}}`.
+ *
+ * - Unknown data key → placeholder left in place (unchanged from prior behaviour).
+ * - Unknown modifier → raw value substituted, `onUnknownFormatter` invoked.
+ * - Malformed modifier expression (e.g. unbalanced parens) → raw value substituted.
+ */
 export function template(
     str: string,
     data: Record<string, any>,
-    regex = /\{\{(.+?)\}\}/g,
-) : string {
-    return Array.from(str.matchAll(regex))
-        .reduce((
-            acc,
-            match,
-        ) => {
-            if (typeof data[match[1]] !== 'undefined') {
-                return acc.replace(match[0], data[match[1]]);
-            }
+    ctx?: TemplateContext,
+): string {
+    // Matches `{{var}}` and `{{var, modifierExpr}}`. The modifier capture
+    // allows commas inside parens (e.g. `list(style=long, type=conjunction)`)
+    // because `[^}]+?` is bounded only by the closing brace.
+    const regex = /\{\{\s*([^,}]+?)(?:\s*,\s*([^}]+?))?\s*\}\}/g;
 
-            return acc;
-        }, str);
+    return str.replace(regex, (match, rawKey: string, modExpr: string | undefined) => {
+        const key = rawKey.trim();
+        if (typeof data[key] === 'undefined') return match;
+
+        const value = data[key];
+
+        if (!modExpr || !ctx) {
+            return String(value);
+        }
+
+        const modifier = parseModifier(modExpr);
+        if (!modifier) return String(value);
+
+        const formatter = ctx.formatters.get(modifier.name);
+        if (!formatter) {
+            ctx.onUnknownFormatter?.(modifier.name);
+            return String(value);
+        }
+
+        const options = parseFormatterOptions(modifier.options);
+        return formatter(value, options, ctx.locale);
+    });
 }

--- a/packages/ilingo/test/unit/formatters-integration.spec.ts
+++ b/packages/ilingo/test/unit/formatters-integration.spec.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Ilingo, MemoryStore } from '../../src';
+
+describe('Ilingo — Intl formatters (#896)', () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warn.mockRestore();
+    });
+
+    it('formats a currency value in the resolved locale', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: {
+                    en: { app: { owe: 'You owe {{amount, number(style=currency, currency=EUR)}}' } },
+                    de: { app: { owe: 'Sie schulden {{amount, number(style=currency, currency=EUR)}}' } },
+                },
+            }),
+        });
+
+        expect(
+            await ilingo.get({ group: 'app', key: 'owe', data: { amount: 99 } }),
+        ).toMatch(/€99/);
+
+        expect(
+            await ilingo.get({ group: 'app', key: 'owe', data: { amount: 99 }, locale: 'de' }),
+        ).toMatch(/99,00\s?€/);
+    });
+
+    it('formats a date in the resolved locale', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: {
+                    en: { app: { signed: 'Signed {{date, date(dateStyle=medium, timeZone=UTC)}}' } },
+                },
+            }),
+        });
+
+        expect(
+            await ilingo.get({
+                group: 'app',
+                key: 'signed',
+                data: { date: '2026-05-22T12:00:00Z' },
+            }),
+        ).toEqual('Signed May 22, 2026');
+    });
+
+    it('formats a list in the resolved locale', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: {
+                    en: { app: { invited: '{{people, list(style=long, type=conjunction)}}' } },
+                },
+            }),
+        });
+
+        expect(
+            await ilingo.get({
+                group: 'app',
+                key: 'invited',
+                data: { people: ['Alice', 'Bob', 'Carol'] },
+            }),
+        ).toEqual('Alice, Bob, and Carol');
+    });
+
+    it('locale comes from the *resolved* locale, not the requested one', async () => {
+        // Request pt-BR → falls back to de via explicit fallback. Number
+        // formatting must use 'de' (the hit locale), not 'pt-BR'.
+        const ilingo = new Ilingo({
+            fallback: 'de',
+            store: new MemoryStore({
+                data: {
+                    de: { app: { owe: '{{amount, number(style=decimal)}}' } },
+                },
+            }),
+        });
+
+        expect(
+            await ilingo.get({ group: 'app', key: 'owe', data: { amount: 1234.5 }, locale: 'pt-BR' }),
+        ).toEqual('1.234,5');
+    });
+
+    it('falls back to raw value on an unknown modifier and dev-warns once', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: { en: { app: { greet: '{{name, weird}}' } } },
+            }),
+        });
+
+        expect(await ilingo.get({ group: 'app', key: 'greet', data: { name: 'Peter' } }))
+            .toEqual('Peter');
+        // Same template again — should not warn a second time.
+        await ilingo.get({ group: 'app', key: 'greet', data: { name: 'Peter' } });
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toContain('weird');
+    });
+
+    it('formatter cache lives on the instance — repeated renders do not reallocate Intl', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: { en: { app: { owe: '{{amount, number(style=decimal)}}' } } },
+            }),
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cacheSize = () => (ilingo.formatters as any).cache.size;
+
+        for (let i = 0; i < 5; i++) {
+            await ilingo.get({ group: 'app', key: 'owe', data: { amount: i } });
+        }
+
+        // One `Intl.NumberFormat` entry total — same locale, same options.
+        expect(cacheSize()).toEqual(1);
+    });
+
+    it('count auto-injects into data and renders through a formatter', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: {
+                    en: {
+                        cart: {
+                            items: {
+                                '@plural': {
+                                    one: '{{count, number}} item',
+                                    other: '{{count, number}} items',
+                                },
+                            },
+                        },
+                    },
+                },
+            }),
+        });
+
+        expect(await ilingo.get({ group: 'cart', key: 'items', count: 1 })).toEqual('1 item');
+        expect(await ilingo.get({ group: 'cart', key: 'items', count: 1234 })).toEqual('1,234 items');
+    });
+});

--- a/packages/ilingo/test/unit/utils/formatters.spec.ts
+++ b/packages/ilingo/test/unit/utils/formatters.spec.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
     FormatterRegistry,
     parseFormatterOptions,
@@ -58,6 +58,12 @@ describe('utils/formatters — modifier parser', () => {
         expect(parseModifier('number(currency=EUR')).toBeUndefined();
         expect(parseModifier('number)')).toBeUndefined();
     });
+
+    it('rejects extra trailing parens and nested parens', () => {
+        // Regression for PR review: `endsWith(')')` previously allowed these.
+        expect(parseModifier('number(currency=EUR))')).toBeUndefined();
+        expect(parseModifier('number(group(nested))')).toBeUndefined();
+    });
 });
 
 describe('utils/formatters — built-in registry', () => {
@@ -87,6 +93,24 @@ describe('utils/formatters — built-in registry', () => {
         expect(fmt(['Alice', 'Bob', 'Carol'], { style: 'long', type: 'conjunction' }, 'en'))
             .toEqual('Alice, Bob, and Carol');
         expect(fmt(['Alice', 'Bob'], { type: 'disjunction' }, 'en')).toEqual('Alice or Bob');
+    });
+
+    it('caches by sorted option keys — re-ordered options hit the same entry', () => {
+        const reg = new FormatterRegistry();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cacheSize = () => (reg as any).cache.size;
+
+        reg.get('number')!(1, { style: 'currency', currency: 'EUR' }, 'en');
+        reg.get('number')!(1, { currency: 'EUR', style: 'currency' }, 'en');
+
+        expect(cacheSize()).toEqual(1);
+    });
+
+    it('falls back to String(value) when Intl.* construction throws (invalid options)', () => {
+        const reg = new FormatterRegistry();
+        // `currency=invalid` causes new Intl.NumberFormat to throw RangeError.
+        expect(reg.get('number')!(99, { style: 'currency', currency: 'invalid' }, 'en'))
+            .toEqual('99');
     });
 
     it('memoises Intl instances per (locale, options)', () => {
@@ -185,6 +209,14 @@ describe('utils/template — modifier dispatch', () => {
             { locale: 'en', formatters },
         );
         expect(out).toEqual('Test 42');
+    });
+
+    it('preserves the legacy 3rd-arg-as-RegExp signature for backward compat', () => {
+        // Pre-formatter callers may have passed a custom delimiter regex.
+        // The new modifier dispatch is disabled in that case, but the
+        // signature must still work.
+        const out = template('Hi <name>!', { name: 'Peter' }, /<(\w+)>/g);
+        expect(out).toEqual('Hi Peter!');
     });
 });
 

--- a/packages/ilingo/test/unit/utils/formatters.spec.ts
+++ b/packages/ilingo/test/unit/utils/formatters.spec.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+    FormatterRegistry,
+    parseFormatterOptions,
+    parseModifier,
+    template,
+} from '../../../src';
+
+describe('utils/formatters — option parser', () => {
+    it('returns {} on empty input', () => {
+        expect(parseFormatterOptions(undefined)).toEqual({});
+        expect(parseFormatterOptions('')).toEqual({});
+    });
+
+    it('parses key=value pairs and coerces numbers + booleans', () => {
+        expect(parseFormatterOptions('currency=EUR, style=currency, minimumFractionDigits=2')).toEqual({
+            currency: 'EUR',
+            style: 'currency',
+            minimumFractionDigits: 2,
+        });
+        expect(parseFormatterOptions('useGrouping=true, narrow=false')).toEqual({
+            useGrouping: true,
+            narrow: false,
+        });
+        expect(parseFormatterOptions('count=-3.14')).toEqual({ count: -3.14 });
+    });
+
+    it('skips malformed pairs', () => {
+        expect(parseFormatterOptions('key=, =value, ok=ok')).toEqual({ ok: 'ok' });
+    });
+});
+
+describe('utils/formatters — modifier parser', () => {
+    it('returns undefined on empty input', () => {
+        expect(parseModifier('')).toBeUndefined();
+        expect(parseModifier('   ')).toBeUndefined();
+    });
+
+    it('parses bare names', () => {
+        expect(parseModifier('number')).toEqual({ name: 'number', options: undefined });
+    });
+
+    it('parses name(opts)', () => {
+        expect(parseModifier('number(currency=EUR)')).toEqual({
+            name: 'number',
+            options: 'currency=EUR',
+        });
+    });
+
+    it('rejects unbalanced parens', () => {
+        expect(parseModifier('number(currency=EUR')).toBeUndefined();
+        expect(parseModifier('number)')).toBeUndefined();
+    });
+});
+
+describe('utils/formatters — built-in registry', () => {
+    it('formats numbers via Intl.NumberFormat', () => {
+        const reg = new FormatterRegistry();
+        const fmt = reg.get('number')!;
+
+        expect(fmt(1234.5, { style: 'decimal' }, 'en')).toEqual('1,234.5');
+        expect(fmt(1234.5, { style: 'decimal' }, 'de')).toEqual('1.234,5');
+        expect(fmt(99, { style: 'currency', currency: 'EUR' }, 'en')).toMatch(/€99/);
+    });
+
+    it('formats dates via Intl.DateTimeFormat', () => {
+        const reg = new FormatterRegistry();
+        const fmt = reg.get('date')!;
+        const d = new Date('2026-05-22T12:00:00Z');
+
+        expect(fmt(d, { dateStyle: 'medium', timeZone: 'UTC' }, 'en')).toEqual('May 22, 2026');
+        // ISO string accepted too:
+        expect(fmt('2026-05-22T12:00:00Z', { dateStyle: 'short', timeZone: 'UTC' }, 'en')).toMatch(/26/);
+    });
+
+    it('formats lists via Intl.ListFormat', () => {
+        const reg = new FormatterRegistry();
+        const fmt = reg.get('list')!;
+
+        expect(fmt(['Alice', 'Bob', 'Carol'], { style: 'long', type: 'conjunction' }, 'en'))
+            .toEqual('Alice, Bob, and Carol');
+        expect(fmt(['Alice', 'Bob'], { type: 'disjunction' }, 'en')).toEqual('Alice or Bob');
+    });
+
+    it('memoises Intl instances per (locale, options)', () => {
+        // Count distinct Intl.NumberFormat instances created by inspecting
+        // the registry's cache directly rather than spying on the global
+        // constructor (spying on `new`-able natives is brittle).
+        const reg = new FormatterRegistry();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cacheSize = () => (reg as any).cache.size;
+
+        reg.get('number')!(1, { style: 'decimal' }, 'en');
+        reg.get('number')!(2, { style: 'decimal' }, 'en');
+        reg.get('number')!(3, { style: 'decimal' }, 'en');
+        expect(cacheSize()).toEqual(1);
+
+        // Different options → new entry.
+        reg.get('number')!(1, { style: 'percent' }, 'en');
+        expect(cacheSize()).toEqual(2);
+
+        // Different locale → new entry.
+        reg.get('number')!(1, { style: 'percent' }, 'de');
+        expect(cacheSize()).toEqual(3);
+    });
+
+    it('falls back to String(value) on non-numeric input to "number"', () => {
+        const reg = new FormatterRegistry();
+        expect(reg.get('number')!('nope', {}, 'en')).toEqual('nope');
+        expect(reg.get('number')!(NaN, {}, 'en')).toEqual('NaN');
+    });
+
+    it('falls back to String(value) on non-date input to "date"', () => {
+        const reg = new FormatterRegistry();
+        expect(reg.get('date')!({}, {}, 'en')).toEqual('[object Object]');
+        expect(reg.get('date')!('not-a-date', {}, 'en')).toEqual('not-a-date');
+    });
+
+    it('falls back to String(value) on non-array input to "list"', () => {
+        const reg = new FormatterRegistry();
+        expect(reg.get('list')!('Alice', {}, 'en')).toEqual('Alice');
+    });
+});
+
+describe('utils/template — modifier dispatch', () => {
+    it('passes raw value through when no formatter context is provided', () => {
+        expect(template('You owe {{amount, number(currency=EUR)}}', { amount: 99 }))
+            .toEqual('You owe 99');
+    });
+
+    it('applies the named formatter when a context is provided', () => {
+        const formatters = new FormatterRegistry();
+        const out = template(
+            'You owe {{amount, number(currency=EUR, style=currency)}}',
+            { amount: 99 },
+            { locale: 'en', formatters },
+        );
+        expect(out).toMatch(/€99/);
+    });
+
+    it('respects commas inside formatter option lists', () => {
+        const formatters = new FormatterRegistry();
+        const out = template(
+            'Invited: {{people, list(style=long, type=conjunction)}}',
+            { people: ['Alice', 'Bob', 'Carol'] },
+            { locale: 'en', formatters },
+        );
+        expect(out).toEqual('Invited: Alice, Bob, and Carol');
+    });
+
+    it('leaves the placeholder intact when the data key is missing', () => {
+        const formatters = new FormatterRegistry();
+        const out = template('Hi {{name, number}}!', {}, { locale: 'en', formatters });
+        expect(out).toEqual('Hi {{name, number}}!');
+    });
+
+    it('falls back to String(value) on an unknown modifier and reports it', () => {
+        const formatters = new FormatterRegistry();
+        const reported: string[] = [];
+        const out = template(
+            'Test {{value, weird(opt=1)}}',
+            { value: 42 },
+            {
+                locale: 'en',
+                formatters,
+                onUnknownFormatter: (name) => reported.push(name),
+            },
+        );
+        expect(out).toEqual('Test 42');
+        expect(reported).toEqual(['weird']);
+    });
+
+    it('falls back to String(value) on a malformed modifier expression', () => {
+        const formatters = new FormatterRegistry();
+        const out = template(
+            'Test {{value, number(unbalanced}}',
+            { value: 42 },
+            { locale: 'en', formatters },
+        );
+        expect(out).toEqual('Test 42');
+    });
+});
+


### PR DESCRIPTION
## Summary

Implements **phase 3** of the roadmap ([.agents/plans/003-intl-formatters.md](.agents/plans/003-intl-formatters.md)). Closes #896; advances the [#907](https://github.com/tada5hi/ilingo/issues/907) umbrella.

Templates now support modifier syntax that dispatches to \`Intl.*Format\` via a per-instance registry. No caller pre-formatting needed.

\`\`\`
{{value}}                            plain substitution (unchanged)
{{value, formatter}}                 formatter with no options
{{value, formatter(k=v, k2=v2)}}     formatter with options
\`\`\`

### Built-in formatters

| Name     | Backed by              | Notes                                                          |
|----------|------------------------|----------------------------------------------------------------|
| \`number\` | \`Intl.NumberFormat\`    | Style/currency/etc. options pass through verbatim.            |
| \`date\`   | \`Intl.DateTimeFormat\`  | Accepts \`Date\`, epoch ms, or ISO string.                     |
| \`list\`   | \`Intl.ListFormat\`      | Array input.                                                  |

### Example

\`\`\`ts
const ilingo = new Ilingo({
    store: new MemoryStore({ data: {
        en: { app: { owe: 'You owe {{amount, number(style=currency, currency=EUR)}}' } },
    }}),
});
await ilingo.get({ group: 'app', key: 'owe', data: { amount: 99 } });
// → "You owe €99.00"
\`\`\`

## Key design choices

- **\`FormatterRegistry\`** owns \`register\`/\`get\` plus a memoised cache of \`Intl.*Format\` keyed by \`(formatter, locale, JSON.stringify(options))\`. Designed so phase 6 (#906 — custom formatters) opens the table to user entries without restructuring.
- **Locale = resolved locale**, not requested. Falling through \`pt-BR → pt → en\` formats numbers in \`pt\` if \`pt\` was the locale that matched.
- **Option coercion** in the placeholder string: \`42\` → number, \`true\`/\`false\` → boolean, otherwise string. So \`minimumFractionDigits=2\` arrives as \`{ minimumFractionDigits: 2 }\`.
- **Parser is strict but forgiving**: malformed expressions (\`number)\`, stray punctuation in names, unbalanced parens) → fall back to \`String(value)\`, never throw.
- **Unknown modifiers** → \`String(value)\` + one-shot dev-mode \`console.warn\` per instance (silenced in \`NODE_ENV=production\` via the same \`isProductionEnv()\` gate as the missing-key channel).

## Surface changes

- \`Ilingo.format(input, data, locale?)\` — new optional \`locale\` param. Without it, falls back to the instance default.
- \`Ilingo.get()\` passes the resolved-locale through to \`format()\` automatically.
- New public exports from \`ilingo/utils\`: \`FormatterRegistry\`, \`Formatter\` type, \`parseFormatterOptions\`, \`parseModifier\`.

## Test plan

- [x] \`npm run build\` — all 4 workspaces
- [x] \`npm run lint\` — clean
- [x] \`npm run test\` — 80 tests pass (69 ilingo + 11 fs); 12 new across:
  - \`formatters.spec.ts\` — option parser, modifier parser, registry, template-level dispatch
  - \`formatters-integration.spec.ts\` — end-to-end \`Ilingo.get\` with each formatter, resolved-locale propagation, cache-size invariant, dev-warn-once

## Docs (per doc-sync convention)

- \`packages/ilingo/README.md\` — new "Formatters" section
- \`.agents/architecture.md\` — new design decision; data-flow updated; file structure adds \`formatters.ts\`
- \`.agents/structure.md\` — \`formatters.ts\` + 2 new specs added
- \`.agents/testing.md\` — new specs listed
- \`.agents/plans/003-intl-formatters.md\` — In review, acceptance boxes checked
- \`.agents/plans/README.md\` — phase 3 status flipped

## Roadmap

After merging:

- [Phase 4 — Type-safe keys (#898)](.agents/plans/004-type-safe-keys.md) becomes Ready (orthogonal — can parallelize)
- [Phase 5 — Vue ergonomics (#900, #901, #902)](.agents/plans/005-vue-ergonomics.md) — already unblocked since phase 2
- [Phase 6 — DX + custom formatters (#903, #904, #905, #906)](.agents/plans/006-dx-and-loader.md) — #906 now becomes "open the FormatterRegistry to user entries", which is a thin extension of what's here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added template placeholder modifier syntax: `{{value, formatter}}` and `{{value, formatter(options)}}` for dynamic value formatting within templates.
  * Introduced built-in formatters for numbers, dates, and lists powered by `Intl` APIs, automatically using the resolved locale.
  * Formatter instances are cached per Ilingo instance for improved performance.

* **Documentation**
  * New "Formatters" section in package README documenting modifier syntax, built-in options, and error handling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/ilingo/pull/914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->