### PR TITLE
feat(ilingo): generic Ilingo<Catalog> with type-safe keys

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -61,6 +61,8 @@ Helpers in `packages/ilingo/src/types.ts`:
 
 `defineCatalog<const T>(c)` (`packages/ilingo/src/catalog.ts`) is a runtime identity function with a `const` generic that captures the catalog literal without losing inference — saves callers from sprinkling `as const`.
 
+`definePlural<const T>(plural)` is the TS/JS-friendly companion to the explicit `@plural` JSON marker. Returns `{ '@plural': leaf }` — same runtime shape as the JSON literal — with CLDR-category autocomplete and a compile error on missing-`other` / non-CLDR keys. Both forms produce identical runtime data: JSON files keep using the `"@plural"` literal (they can't call functions), TS/JS files use `definePlural()`.
+
 ### 8. ESM-first, dependency-light, browser-safe
 
 Each package's runtime dependencies are minimal — `pathtrace` and `smob` in core; `locter`, `pathe`, `smob` in `@ilingo/fs`. Vue and Vuelidate are declared as `peerDependencies`, not bundled. Core does not import `node:process` — `NODE_ENV` is read via a bare `process.env.NODE_ENV` literal (so Vite / Webpack DefinePlugin can replace it) wrapped in a `typeof process !== 'undefined'` guard for raw-browser execution.

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -47,7 +47,21 @@ Template placeholders accept modifier syntax: `{{value, formatter}}` and `{{valu
 
 The locale handed to a formatter is the **resolved** locale (the one that actually yielded the message), not the requested one. Unknown modifiers fall back to `String(value)` and emit a per-instance dev-mode one-shot warning via the same `isProductionEnv()` gate used by the missing-key handler.
 
-### 7. ESM-first, dependency-light, browser-safe
+### 7. Type-safe keys via a generic `Ilingo<Catalog>`
+
+`Ilingo` is generic in the catalog: `class Ilingo<C extends LocalesRecord = LocalesRecord>`. When `C` is the default `LocalesRecord` (no generic supplied) the API stays as loose as before — `group: string`, `key: string`. When `C` is a concrete catalog, `Groups<C>` / `Key<C, G>` infer the legal pairs and `IsPluralKey<C, G, K>` makes `count` *required* at the type level for plural leaves.
+
+Helpers in `packages/ilingo/src/types.ts`:
+
+- `AnyGroups<C>` — pick any locale's group map (catalogs SHOULD share a shape across locales).
+- `Groups<C>` — union of top-level group names.
+- `LeafAt<T, K>` — walk a dotted key path through a typed object; `never` on miss.
+- `DottedPaths<T>` — enumerate all dotted leaf paths; short-circuits to `string` for open-shape inputs (so `LocalesRecord` reduces to a `string`-typed key, not `never`).
+- `Key<C, G>`, `IsPluralKey<C, G, K>`, `GetParams<C, G, K>`.
+
+`defineCatalog<const T>(c)` (`packages/ilingo/src/catalog.ts`) is a runtime identity function with a `const` generic that captures the catalog literal without losing inference — saves callers from sprinkling `as const`.
+
+### 8. ESM-first, dependency-light, browser-safe
 
 Each package's runtime dependencies are minimal — `pathtrace` and `smob` in core; `locter`, `pathe`, `smob` in `@ilingo/fs`. Vue and Vuelidate are declared as `peerDependencies`, not bundled. Core does not import `node:process` — `NODE_ENV` is read via a bare `process.env.NODE_ENV` literal (so Vite / Webpack DefinePlugin can replace it) wrapped in a `typeof process !== 'undefined'` guard for raw-browser execution.
 
@@ -176,6 +190,7 @@ Output:
 packages/ilingo/src/
 ├── module.ts                ← orchestrator (Ilingo class)
 ├── store/{types,memory}     ← port + default adapter
+├── catalog.ts               ← defineCatalog<const T>() helper
 ├── utils/
 │   ├── locale.ts            ← bcp47Parents, resolveLocaleChain
 │   ├── identify.ts          ← isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord, PLURAL_MARKER

--- a/.agents/plans/004-type-safe-keys.md
+++ b/.agents/plans/004-type-safe-keys.md
@@ -27,7 +27,8 @@ Infer the legal `(group, key)` pairs from a typed catalog so the compiler catche
 - [x] Plural-shaped leaves (both `@plural`-wrapped and structural) require `count: number` at the call site — calling without `count` is a type error.
 - [x] No runtime change — all 84 existing `.spec.ts` cases pass unchanged.
 - [x] `IStore` left non-generic (catalog flows through `Ilingo<C>` only, not stores) — keeps custom store implementations simple at the cost of not propagating the catalog into store-level types. Acceptable trade-off; revisit if a concrete use case appears.
-- [x] Type tests live in `test/unit/types.spec-d.ts`, run via `npm run test:types` (vitest `--typecheck`). 10 type tests, no errors. Vue composable not made generic in this pass — the call site uses an injected (loosely typed) instance; module-augmentation pattern (`declare module '@ilingo/vue' { interface IlingoCatalog { ... } }`) belongs to a follow-up.
+- [x] Type tests live in `test/unit/types.spec-d.ts`, run via `npm run test:types` (vitest `--typecheck`). 13 type tests, no errors. Vue composable not made generic in this pass — the call site uses an injected (loosely typed) instance; module-augmentation pattern (`declare module '@ilingo/vue' { interface IlingoCatalog { ... } }`) belongs to a follow-up.
+- [x] `definePlural<const T>(leaf)` helper added alongside `defineCatalog`. TS/JS authors get autocomplete + literal-type capture; JSON authors continue with the string-key `@plural` marker (JSON can't call functions). Both produce identical runtime data.
 
 ## Why now
 

--- a/.agents/plans/004-type-safe-keys.md
+++ b/.agents/plans/004-type-safe-keys.md
@@ -1,6 +1,6 @@
 # Phase 4 — Type-safe key inference
 
-**Status**: Blocked by Phase 2 (plural-shaped leaves change the catalog type).
+**Status**: In review (branch `feat/type-safe-keys`).
 **Tracks**: [#898](https://github.com/tada5hi/ilingo/issues/898).
 
 Infer the legal `(group, key)` pairs from a typed catalog so the compiler catches typos and renames.
@@ -23,9 +23,11 @@ Infer the legal `(group, key)` pairs from a typed catalog so the compiler catche
 
 ## Acceptance
 
-- [ ] `ilingo.get({ group: 'app', key: 'unknown' })` errors at compile time when typed with a concrete catalog.
-- [ ] Plural-shaped leaves accept `{ count: number }` and require it (so `ilingo.get({ group, key })` errors when the leaf is plural-only).
-- [ ] No runtime change — existing `.spec.ts` cases still pass unchanged.
+- [x] `ilingo.get({ group: 'app', key: 'unknown' })` errors at compile time when typed with a concrete catalog. Dotted paths (`'nested.deep.leaf'`) are inferred too.
+- [x] Plural-shaped leaves (both `@plural`-wrapped and structural) require `count: number` at the call site — calling without `count` is a type error.
+- [x] No runtime change — all 84 existing `.spec.ts` cases pass unchanged.
+- [x] `IStore` left non-generic (catalog flows through `Ilingo<C>` only, not stores) — keeps custom store implementations simple at the cost of not propagating the catalog into store-level types. Acceptable trade-off; revisit if a concrete use case appears.
+- [x] Type tests live in `test/unit/types.spec-d.ts`, run via `npm run test:types` (vitest `--typecheck`). 10 type tests, no errors. Vue composable not made generic in this pass — the call site uses an injected (loosely typed) instance; module-augmentation pattern (`declare module '@ilingo/vue' { interface IlingoCatalog { ... } }`) belongs to a follow-up.
 
 ## Why now
 

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -7,7 +7,7 @@ Phased roadmap for ilingo, sequenced to land coherent waves of work rather than 
 | 1     | [001-dependency-cleanup.md](001-dependency-cleanup.md) | Done        | Post-modernization hygiene      |
 | 2     | [002-resolution-path.md](002-resolution-path.md)       | In review   | #895, #897, #899                |
 | 3     | [003-intl-formatters.md](003-intl-formatters.md)       | In review   | #896                            |
-| 4     | [004-type-safe-keys.md](004-type-safe-keys.md)         | Blocked by 2| #898                            |
+| 4     | [004-type-safe-keys.md](004-type-safe-keys.md)         | In review   | #898                            |
 | 5     | [005-vue-ergonomics.md](005-vue-ergonomics.md)         | Blocked by 2| #900, #901, #902                |
 | 6     | [006-dx-and-loader.md](006-dx-and-loader.md)           | Blocked by 5| #903, #904, #905, #906          |
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -39,7 +39,9 @@ src/
 ├── module.ts                 # Ilingo class — Set<IStore>, locale + fallback chain, plural rules cache,
 │                             #   per-instance warn-once memo, get / getResolvedLocale[Chain] / merge / format
 ├── types.ts                  # LinesRecord, Leaf, PluralLeaf, PluralLeafExplicit, GetContext (with count),
-│                             #   MissingKeyContext, MissingKeyHandler, Fallback, FallbackResolver, Data
+│                             #   MissingKeyContext, MissingKeyHandler, Fallback, FallbackResolver, Data,
+│                             #   AnyGroups, Groups, Key, LeafAt, DottedPaths, IsPluralKey, GetParams
+├── catalog.ts                # defineCatalog<const T>() identity helper
 ├── constants.ts              # LOCALE_DEFAULT = 'en'
 ├── config/
 │   ├── index.ts
@@ -63,6 +65,7 @@ test/
     ├── module.spec.ts                # legacy core behaviour
     ├── resolution.spec.ts            # plural, fallback chain, missing-key handler, parallel lookup
     ├── formatters-integration.spec.ts # Ilingo.get() with number/date/list modifiers, cache + dev-warn
+    ├── types.spec-d.ts               # compile-time-only — run via `npm run test:types` (vitest typecheck)
     └── utils/
         ├── locale.spec.ts            # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
         ├── formatters.spec.ts        # parseFormatterOptions, parseModifier, FormatterRegistry, template dispatch

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -41,7 +41,7 @@ src/
 ├── types.ts                  # LinesRecord, Leaf, PluralLeaf, PluralLeafExplicit, GetContext (with count),
 │                             #   MissingKeyContext, MissingKeyHandler, Fallback, FallbackResolver, Data,
 │                             #   AnyGroups, Groups, Key, LeafAt, DottedPaths, IsPluralKey, GetParams
-├── catalog.ts                # defineCatalog<const T>() identity helper
+├── catalog.ts                # defineCatalog<const T>() + definePlural<const T>() typed helpers
 ├── constants.ts              # LOCALE_DEFAULT = 'en'
 ├── config/
 │   ├── index.ts

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -33,6 +33,10 @@ unit/
 │                                   #   handler, per-instance warn isolation, parallel intra-locale lookup
 ├── formatters-integration.spec.ts  # end-to-end Ilingo.get() with number/date/list modifiers,
 │                                   #   resolved-locale propagation, per-instance cache, dev-warn
+├── types.spec-d.ts                 # compile-time-only — typed-catalog inference, plural-key
+│                                   #   count requirement, defineCatalog narrowing.
+│                                   #   Run via `npm run test:types --workspace=packages/ilingo`
+│                                   #   (vitest --typecheck against `*.spec-d.ts`)
 └── utils/
     ├── identify.spec.ts            # isLineRecord / isPluralLeaf / isPluralLeafExplicit
     ├── locale.spec.ts              # bcp47Parents, resolveLocaleChain (incl. opt-out forms)

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -292,18 +292,35 @@ await ilingo.get({ group: 'cart', key: 'items', count: 5 });
 
 If the selected category is absent from the leaf, `other` is used as a fallback.
 
-**Recommended explicit form.** Prefer wrapping plural forms in `{ "@plural": { ... } }` to disambiguate them from regular namespaces that happen to use CLDR category names:
+**Recommended explicit form.** Wrap plural forms in `{ "@plural": { ... } }` to disambiguate them from regular namespaces that happen to use CLDR category names. The right syntax depends on how you author your locale data:
+
+**JSON files** (loaded by `FSStore`) — use the literal `@plural` key:
+
+```json
+{
+    "cart": {
+        "items": {
+            "@plural": {
+                "one": "{{count}} item",
+                "other": "{{count}} items"
+            }
+        }
+    }
+}
+```
+
+**TS / JS files** (inline `defineCatalog`, or loaded by `FSStore`) — use the `definePlural` helper:
 
 ```typescript
-{
+import { defineCatalog, definePlural } from 'ilingo';
+
+const catalog = defineCatalog({
     en: {
         cart: {
-            items: {
-                '@plural': {
-                    one: '{{count}} item',
-                    other: '{{count}} items',
-                },
-            },
+            items: definePlural({
+                one: '{{count}} item',
+                other: '{{count}} items',
+            }),
         },
         form: {
             kind: {
@@ -312,8 +329,10 @@ If the selected category is absent from the leaf, `other` is used as a fallback.
             },
         },
     },
-}
+});
 ```
+
+`definePlural` is a thin identity helper — it returns `{ '@plural': leaf }` with the same runtime shape as the JSON form. The `const` generic preserves the literal types of each plural form (so `Ilingo<typeof catalog>` still sees them as plural keys requiring `count`). The TS/JS version gets CLDR-category autocomplete and a compile error if you misspell `other` or pass a non-CLDR key.
 
 Structural detection (a bare `{ one, other }` object without the marker) is still supported for backward compatibility.
 

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -22,6 +22,7 @@ Ilingo is a lightweight library for translation and internationalization.
   - [Fallback locale chain](#fallback-locale-chain)
   - [Missing-key handler](#missing-key-handler)
   - [Formatters](#formatters)
+  - [Type-safe keys](#type-safe-keys)
 - [Store](#store)
   - [Memory](#memory-store)
   - [FileSystem](#fs-store)
@@ -403,6 +404,49 @@ The locale used to construct the `Intl.*Format` instance is the **resolved** loc
 Option-value coercion: `42` → `42` (number), `true` / `false` → boolean, anything else → string. So `currency=EUR` becomes `{ currency: 'EUR' }`, `minimumFractionDigits=2` becomes `{ minimumFractionDigits: 2 }`.
 
 Unknown modifiers fall back to `String(value)` and emit a one-shot dev-mode warning (silenced in `process.env.NODE_ENV === 'production'`). Malformed modifier expressions (unbalanced parens, non-identifier names) are treated the same way — never throw.
+
+### Type-safe keys
+
+`Ilingo` is generic in the catalog shape. Wrap your catalog with `defineCatalog` to capture its narrowest literal types, pass it as the type parameter to `Ilingo`, and the compiler refuses typos, unknown groups, and plural-key calls that forget `count`.
+
+```typescript
+import { Ilingo, MemoryStore, defineCatalog } from 'ilingo';
+
+const catalog = defineCatalog({
+    en: {
+        app: {
+            greeting: 'Hi {{name}}',
+            nested: { deep: { leaf: 'Deep value' } },
+        },
+        cart: {
+            items: {
+                '@plural': {
+                    one: '{{count}} item',
+                    other: '{{count}} items',
+                },
+            },
+        },
+    },
+    de: { /* …same shape… */ },
+});
+
+const ilingo = new Ilingo<typeof catalog>({
+    store: new MemoryStore({ data: catalog }),
+});
+
+await ilingo.get({ group: 'app', key: 'greeting' });           // OK
+await ilingo.get({ group: 'app', key: 'nested.deep.leaf' });   // OK — dotted paths inferred
+await ilingo.get({ group: 'app', key: 'unknown' });            // ❌ type error
+await ilingo.get({ group: 'unknown', key: 'greeting' });       // ❌ type error
+await ilingo.get({ group: 'cart',  key: 'items' });            // ❌ type error — count is required
+await ilingo.get({ group: 'cart',  key: 'items', count: 1 });  // OK
+```
+
+`defineCatalog<const T>(catalog)` uses TS 5+ const-generic inference so per-key literals (and structural plural leaves) aren't widened to `string`. The runtime function is a no-op identity — purely a type carrier.
+
+Inference is structural, derived from the union of locales. Keep all locales aligned to the same shape and the inferred `Key<C, G>` is the natural set of leaf paths. Diverging locales widen the union but never break compilation.
+
+`new Ilingo()` (no generic) preserves today's loose typing — `group: string, key: string` are accepted. The generic is opt-in.
 
 ## Store
 

--- a/packages/ilingo/package.json
+++ b/packages/ilingo/package.json
@@ -31,6 +31,7 @@
         "lint": "eslint",
         "lint:fix": "npm run lint -- --fix",
         "test": "cross-env NODE_ENV=test vitest --config test/vitest.config.ts --run",
+        "test:types": "cross-env NODE_ENV=test vitest --config test/vitest.config.ts --run --typecheck --typecheck.only",
         "test:coverage": "cross-env NODE_ENV=test vitest --config test/vitest.config.ts --run --coverage"
     },
     "engines": {

--- a/packages/ilingo/src/catalog.ts
+++ b/packages/ilingo/src/catalog.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { LocalesRecord } from './types';
+
+/**
+ * Helper that returns its argument unchanged but captures it with `const`
+ * type inference, so the catalog literal keeps its narrowest shape
+ * (per-key string literals, structural plural leaves, etc.) without the
+ * caller having to add `as const` everywhere.
+ *
+ * @example
+ *     const catalog = defineCatalog({
+ *         en: { app: { greeting: 'Hi {{name}}' } },
+ *         de: { app: { greeting: 'Hallo {{name}}' } },
+ *     });
+ *     const ilingo = new Ilingo<typeof catalog>({
+ *         store: new MemoryStore({ data: catalog }),
+ *     });
+ *     ilingo.get({ group: 'app', key: 'greeting' });  // OK
+ *     ilingo.get({ group: 'app', key: 'unknown' });   // type error
+ */
+export function defineCatalog<const T extends LocalesRecord>(catalog: T): T {
+    return catalog;
+}

--- a/packages/ilingo/src/catalog.ts
+++ b/packages/ilingo/src/catalog.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { LocalesRecord } from './types';
+import type { LocalesRecord, PluralLeaf, PluralLeafExplicit } from './types';
 
 /**
  * Helper that returns its argument unchanged but captures it with `const`
@@ -26,4 +26,33 @@ import type { LocalesRecord } from './types';
  */
 export function defineCatalog<const T extends LocalesRecord>(catalog: T): T {
     return catalog;
+}
+
+/**
+ * TS/JS-friendly companion for the explicit `@plural` marker. Wraps the
+ * given CLDR-categorised forms into `{ '@plural': leaf }` — the same
+ * runtime shape an authored JSON file would carry — so callers writing
+ * catalogs in TypeScript don't have to type the magic key by hand.
+ *
+ * The `const` generic preserves the literal type of each plural form for
+ * downstream type inference (e.g. inside `defineCatalog`).
+ *
+ * JSON files cannot call functions, so they continue to use the
+ * `{ "@plural": { "one": "...", "other": "..." } }` literal shape. Both
+ * forms produce identical runtime data.
+ *
+ * @example
+ *     const catalog = defineCatalog({
+ *         en: {
+ *             cart: {
+ *                 items: definePlural({
+ *                     one: '{{count}} item',
+ *                     other: '{{count}} items',
+ *                 }),
+ *             },
+ *         },
+ *     });
+ */
+export function definePlural<const T extends PluralLeaf>(plural: T): { '@plural': T } & PluralLeafExplicit {
+    return { '@plural': plural };
 }

--- a/packages/ilingo/src/index.ts
+++ b/packages/ilingo/src/index.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './catalog';
 export * from './config';
 export * from './module';
 export * from './store';

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -12,7 +12,11 @@ import type {
     Data,
     Fallback,
     GetContext,
+    GetParams,
+    Groups,
+    Key,
     Leaf,
+    LocalesRecord,
     MissingKeyHandler,
 } from './types';
 import {
@@ -41,7 +45,7 @@ function isProductionEnv(): boolean {
     }
 }
 
-export class Ilingo {
+export class Ilingo<C extends LocalesRecord = LocalesRecord> {
     public readonly stores: Set<IStore>;
 
     protected locale: string;
@@ -91,7 +95,7 @@ export class Ilingo {
 
     // ----------------------------------------------------
 
-    merge(instance: Ilingo) {
+    merge(instance: Ilingo<LocalesRecord>) {
         const ownEntries = Array.from(this.stores.values());
         const foreignEntries = Array.from(instance.stores.values());
 
@@ -149,28 +153,34 @@ export class Ilingo {
      * Which locale in the chain actually yielded a value for the given
      * `(group, key)`, or `undefined` if the key is missing in every locale.
      */
-    async getResolvedLocale(ctx: GetContext): Promise<string | undefined> {
-        const chain = this.getResolvedLocaleChain(ctx);
-        const hit = await this.lookup(chain, ctx);
+    async getResolvedLocale<G extends Groups<C>, K extends Key<C, G> & string>(
+        ctx: GetParams<C, G, K>,
+    ): Promise<string | undefined> {
+        const internal = ctx as unknown as GetContext;
+        const chain = this.getResolvedLocaleChain(internal);
+        const hit = await this.lookup(chain, internal);
         return hit?.locale;
     }
 
     // ----------------------------------------------------
 
-    async get(ctx: GetContext): Promise<string | undefined> {
-        const requestedLocale = ctx.locale ?? this.getLocale();
+    async get<G extends Groups<C>, K extends Key<C, G> & string>(
+        ctx: GetParams<C, G, K>,
+    ): Promise<string | undefined> {
+        const internal = ctx as unknown as GetContext;
+        const requestedLocale = internal.locale ?? this.getLocale();
         const chain = this.getResolvedLocaleChain({ locale: requestedLocale });
 
-        const hit = await this.lookup(chain, ctx);
+        const hit = await this.lookup(chain, internal);
 
         if (!hit) {
-            return this.handleMissingKey(ctx, requestedLocale, chain);
+            return this.handleMissingKey(internal, requestedLocale, chain);
         }
 
-        const message = this.selectPluralForm(hit.leaf, hit.locale, ctx.count);
-        const data: Data = { ...(ctx.data || {}) };
-        if (typeof ctx.count === 'number' && typeof data.count === 'undefined') {
-            data.count = ctx.count;
+        const message = this.selectPluralForm(hit.leaf, hit.locale, internal.count);
+        const data: Data = { ...(internal.data || {}) };
+        if (typeof internal.count === 'number' && typeof data.count === 'undefined') {
+            data.count = internal.count;
         }
         return this.format(message, data, hit.locale);
     }

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -95,7 +95,7 @@ export type LeafAt<T, K extends string> =    K extends `${infer Head}.${infer Ta
  * `LinesRecord`) short-circuit to plain `string` — there are no concrete
  * keys to enumerate, so any string is acceptable.
  */
-export type DottedPaths<T> =    string extends keyof T ? string :
+export type DottedPaths<T> = string extends keyof T ? string :
     T extends string ? never :
         T extends PluralLeaf | PluralLeafExplicit ? never :
             T extends Record<string, unknown> ?
@@ -104,7 +104,10 @@ export type DottedPaths<T> =    string extends keyof T ? string :
                     T[K] extends string | PluralLeaf | PluralLeafExplicit ?
                         K :
                         T[K] extends Record<string, unknown> ?
-                                K | `${K}.${DottedPaths<T[K]>}` :
+                            // Only emit dotted leaf paths — never the bare
+                            // intermediate namespace key (which would type-
+                            // check but always miss at runtime).
+                            `${K}.${DottedPaths<T[K]>}` :
                             never;
                 }[keyof T & string] :
                 never;
@@ -120,16 +123,33 @@ export type Key<C extends LocalesRecord, G extends Groups<C>> =    AnyGroups<C>[
 
 /**
  * `true` when the leaf at `(G, K)` is a plural shape (either structural or
- * explicit `@plural`-wrapped). Used to make `count` required at the type
- * level for plural keys.
+ * explicit `@plural`-wrapped) in *any* locale. Used to make `count` required
+ * at the type level for plural keys.
+ *
+ * `LeafAt<...>` for diverging locales returns a union like
+ * `string | PluralLeaf`. A naked `extends PluralLeaf | PluralLeafExplicit`
+ * collapses that to `false`, which would let `count` slip through as
+ * optional. The `Extract<...>` form treats the key as plural when *any*
+ * branch of the union is a plural shape — the safer default, since the
+ * locale that's plural-shaped would otherwise silently fall back to its
+ * `other` form on every call.
+ *
+ * The `[X] extends [never]` wrapping disables the distributive-conditional
+ * behaviour so `never` (no plural anywhere) is detected directly.
  */
+// Open shapes (default LocalesRecord) have a `string` index signature at
+// the group level; their leaf type union always includes `PluralLeaf`,
+// which would make every call site require `count`. Short-circuit to
+// false there — only concrete catalogs participate in plural inference.
 export type IsPluralKey<
     C extends LocalesRecord,
     G extends Groups<C>,
     K extends string,
-> = LeafAt<AnyGroups<C>[G], K> extends PluralLeaf | PluralLeafExplicit ?
-    true :
-    false;
+> = string extends keyof AnyGroups<C>[G] ?
+    false :
+    [Extract<LeafAt<AnyGroups<C>[G], K>, PluralLeaf | PluralLeafExplicit>] extends [never] ?
+        false :
+        true;
 
 /**
  * The full `ctx` argument to `Ilingo.get()` when parameterised with a

--- a/packages/ilingo/src/types.ts
+++ b/packages/ilingo/src/types.ts
@@ -51,6 +51,103 @@ export type GetContext = {
     count?: number,
 };
 
+// ─── Generic catalog navigation ──────────────────────────────────────────────
+//
+// When `Ilingo` is parameterised with a concrete catalog shape, these helpers
+// expose the legal `(group, key)` pairs and detect plural-shaped leaves so the
+// compiler can refuse typos and require `count` where the leaf demands it.
+//
+// All of these collapse to `string` (group / key) and `false` (plural) when
+// `C` is the default `LocalesRecord`, so existing callers keep their unsafe
+// but-loose typing without surprise.
+
+/**
+ * Pick any locale's group map from the catalog. All locales SHOULD share the
+ * same shape; if they diverge, this is the union of all per-locale shapes,
+ * which is the safest default for inference.
+ */
+export type AnyGroups<C extends LocalesRecord> = C[keyof C];
+
+/**
+ * Top-level group names declared by the catalog.
+ */
+export type Groups<C extends LocalesRecord> = keyof AnyGroups<C> & string;
+
+/**
+ * Walk a dotted path through a typed object and return the leaf value.
+ * Returns `never` if the path doesn't exist in the type.
+ */
+export type LeafAt<T, K extends string> =    K extends `${infer Head}.${infer Tail}` ?
+    Head extends keyof T ?
+        LeafAt<T[Head], Tail> :
+        never :
+    K extends keyof T ?
+        T[K] :
+        never;
+
+/**
+ * Enumerate all dotted leaf paths within a typed object. Stops descending at
+ * `string` leaves and at plural leaves (structural or explicit), so a key
+ * like `cart.items` resolves to the plural leaf and not into its inner
+ * `one` / `other`.
+ *
+ * Open shapes (those with a `string` index signature like the default
+ * `LinesRecord`) short-circuit to plain `string` — there are no concrete
+ * keys to enumerate, so any string is acceptable.
+ */
+export type DottedPaths<T> =    string extends keyof T ? string :
+    T extends string ? never :
+        T extends PluralLeaf | PluralLeafExplicit ? never :
+            T extends Record<string, unknown> ?
+                {
+                    [K in keyof T & string]:
+                    T[K] extends string | PluralLeaf | PluralLeafExplicit ?
+                        K :
+                        T[K] extends Record<string, unknown> ?
+                                K | `${K}.${DottedPaths<T[K]>}` :
+                            never;
+                }[keyof T & string] :
+                never;
+
+/**
+ * Legal dotted keys within a specific group of the catalog.
+ */
+export type Key<C extends LocalesRecord, G extends Groups<C>> =    AnyGroups<C>[G] extends infer T ?
+    DottedPaths<T> extends infer P ?
+        P extends string ? P : string :
+        string :
+    string;
+
+/**
+ * `true` when the leaf at `(G, K)` is a plural shape (either structural or
+ * explicit `@plural`-wrapped). Used to make `count` required at the type
+ * level for plural keys.
+ */
+export type IsPluralKey<
+    C extends LocalesRecord,
+    G extends Groups<C>,
+    K extends string,
+> = LeafAt<AnyGroups<C>[G], K> extends PluralLeaf | PluralLeafExplicit ?
+    true :
+    false;
+
+/**
+ * The full `ctx` argument to `Ilingo.get()` when parameterised with a
+ * catalog. Defaults to today's loose `GetContext` when `C` is `LocalesRecord`.
+ *
+ * If the leaf at `(G, K)` is plural, `count: number` is required; otherwise
+ * `count` is optional.
+ */
+export type GetParams<C extends LocalesRecord, G extends Groups<C>, K extends Key<C, G> & string> =    & {
+    data?: Data,
+    locale?: string,
+    group: G,
+    key: K,
+} &
+    (IsPluralKey<C, G, K> extends true ?
+        { count: number } :
+        { count?: number });
+
 export type MissingKeyContext = GetContext & {
     /**
      * The last locale that was tried — the end of the resolved fallback chain.

--- a/packages/ilingo/test/unit/resolution.spec.ts
+++ b/packages/ilingo/test/unit/resolution.spec.ts
@@ -287,6 +287,30 @@ describe('Ilingo — resolution path', () => {
     });
 
     describe('explicit @plural marker', () => {
+        it('definePlural() produces the same runtime shape as the @plural literal', async () => {
+            const { definePlural } = await import('../../src');
+
+            const ilingo = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        en: {
+                            cart: {
+                                items: definePlural({
+                                    one: '{{count}} item',
+                                    other: '{{count}} items',
+                                }),
+                            },
+                        },
+                    },
+                }),
+            });
+
+            expect(await ilingo.get({ group: 'cart', key: 'items', count: 1 }))
+                .toEqual('1 item');
+            expect(await ilingo.get({ group: 'cart', key: 'items', count: 5 }))
+                .toEqual('5 items');
+        });
+
         it('recognises { "@plural": { ... } } as a plural leaf', async () => {
             const ilingo = new Ilingo({
                 store: new MemoryStore({

--- a/packages/ilingo/test/unit/types.spec-d.ts
+++ b/packages/ilingo/test/unit/types.spec-d.ts
@@ -6,7 +6,9 @@
  */
 
 import { describe, expectTypeOf, it } from 'vitest';
-import { Ilingo, MemoryStore, defineCatalog } from '../../src';
+import {
+    Ilingo, MemoryStore, defineCatalog, definePlural,
+} from '../../src';
 
 // A typical typed catalog mixing flat keys, nested namespaces, and both
 // plural forms (structural + explicit).
@@ -132,6 +134,45 @@ describe('Ilingo — no generic preserves backward compat (loose typing)', () =>
         // Without a generic, the API is intentionally loose.
         ilingo.get({ group: 'whatever', key: 'really.anything' });
         ilingo.get({ group: 'whatever', key: 'really.anything', count: 5 });
+    });
+});
+
+describe('definePlural — TS/JS authoring helper', () => {
+    it('produces the same { "@plural": ... } shape as a literal', () => {
+        const a = definePlural({ one: '1 item', other: '{{count}} items' });
+
+        expectTypeOf(a).toMatchTypeOf<{ '@plural': { other: string } }>();
+        // The inner CLDR-categorised shape is preserved.
+        expectTypeOf(a['@plural'].one).toEqualTypeOf<'1 item'>();
+        expectTypeOf(a['@plural'].other).toEqualTypeOf<'{{count}} items'>();
+    });
+
+    it('requires `other` and rejects non-CLDR keys at compile time', () => {
+        // @ts-expect-error `other` is required by PluralLeaf
+        definePlural({ one: 'a' });
+
+        // @ts-expect-error 'foo' is not a CLDR plural category
+        definePlural({ other: 'a', foo: 'b' });
+    });
+
+    it('a catalog leaf written via definePlural is detected as plural', () => {
+        const cat = defineCatalog({
+            en: {
+                cart: {
+                    items: definePlural({ one: '1', other: '{{count}}' }),
+                },
+            },
+        });
+
+        const ilingo = new Ilingo<typeof cat>({
+            store: new MemoryStore({ data: cat }),
+        });
+
+        // count is required because the leaf is plural-shaped
+        ilingo.get({ group: 'cart', key: 'items', count: 2 });
+
+        // @ts-expect-error count is required for plural keys
+        ilingo.get({ group: 'cart', key: 'items' });
     });
 });
 

--- a/packages/ilingo/test/unit/types.spec-d.ts
+++ b/packages/ilingo/test/unit/types.spec-d.ts
@@ -106,6 +106,23 @@ describe('Ilingo<Catalog> — typed key inference', () => {
         });
     });
 
+    it('rejects an intermediate namespace key (not a leaf)', () => {
+        // Regression for PR #915 review: DottedPaths previously included
+        // intermediate `K` (the namespace itself) alongside `K.path`.
+        // The runtime would have returned undefined for that path; rejecting
+        // it at the type level matches the actual contract.
+        ilingo.get({
+            group: 'app',
+            // @ts-expect-error 'nested' is a namespace, not a leaf
+            key: 'nested',
+        });
+        ilingo.get({
+            group: 'app',
+            // @ts-expect-error 'nested.deep' is also a namespace, not a leaf
+            key: 'nested.deep',
+        });
+    });
+
     it('requires `count` for an explicit @plural leaf', () => {
         // OK with count.
         ilingo.get({ group: 'cart', key: 'items', count: 1 });
@@ -124,6 +141,40 @@ describe('Ilingo<Catalog> — typed key inference', () => {
     it('does not require count for a regular string leaf', () => {
         // No count needed when leaf is plain string.
         ilingo.get({ group: 'app', key: 'greeting' });
+    });
+
+    it('requires count when locales diverge and at least one is plural', () => {
+        // Regression for PR #915 review: a naked
+        // `extends PluralLeaf | PluralLeafExplicit` returns false for
+        // unions like `string | PluralLeaf`, letting count slip through as
+        // optional even when one locale needs plural selection. The
+        // `Extract<...>`-based IsPluralKey treats the key as plural when
+        // any branch in the union is plural-shaped.
+        const divergeCatalog = defineCatalog({
+            en: {
+                app: {
+                    items: {
+                        '@plural': { one: '1 item', other: '{{count}} items' },
+                    },
+                },
+            },
+            de: {
+                app: {
+                    // String in German — diverges from English's plural form.
+                    items: 'Artikel',
+                },
+            },
+        });
+
+        const il = new Ilingo<typeof divergeCatalog>({
+            store: new MemoryStore({ data: divergeCatalog }),
+        });
+
+        // OK: count provided.
+        il.get({ group: 'app', key: 'items', count: 1 });
+
+        // @ts-expect-error count is required because en defines a plural shape
+        il.get({ group: 'app', key: 'items' });
     });
 });
 

--- a/packages/ilingo/test/unit/types.spec-d.ts
+++ b/packages/ilingo/test/unit/types.spec-d.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+import { Ilingo, MemoryStore, defineCatalog } from '../../src';
+
+// A typical typed catalog mixing flat keys, nested namespaces, and both
+// plural forms (structural + explicit).
+const catalog = defineCatalog({
+    en: {
+        app: {
+            greeting: 'Hi {{name}}',
+            farewell: 'Bye',
+            nested: {
+                deep: {
+                    leaf: 'Deep value',
+                },
+            },
+        },
+        cart: {
+            // Explicit plural form — recommended.
+            items: {
+                '@plural': {
+                    one: '{{count}} item',
+                    other: '{{count}} items',
+                },
+            },
+            // Structural plural form — backward compat.
+            shipping: {
+                one: 'One package',
+                other: '{{count}} packages',
+            },
+        },
+    },
+    de: {
+        app: {
+            greeting: 'Hallo {{name}}',
+            farewell: 'Tschüss',
+            nested: {
+                deep: {
+                    leaf: 'Tiefer Wert',
+                },
+            },
+        },
+        cart: {
+            items: {
+                '@plural': {
+                    one: '{{count}} Artikel',
+                    other: '{{count}} Artikel',
+                },
+            },
+            shipping: {
+                one: 'Ein Paket',
+                other: '{{count}} Pakete',
+            },
+        },
+    },
+});
+
+type Catalog = typeof catalog;
+
+describe('Ilingo<Catalog> — typed key inference', () => {
+    const ilingo = new Ilingo<Catalog>({
+        store: new MemoryStore({ data: catalog }),
+    });
+
+    it('accepts a flat group/key pair', () => {
+        expectTypeOf(
+            ilingo.get({ group: 'app', key: 'greeting' }),
+        ).resolves.toEqualTypeOf<string | undefined>();
+    });
+
+    it('accepts a dotted nested key', () => {
+        expectTypeOf(
+            ilingo.get({ group: 'app', key: 'nested.deep.leaf' }),
+        ).resolves.toEqualTypeOf<string | undefined>();
+    });
+
+    it('rejects an unknown group at compile time', () => {
+        ilingo.get({
+            // @ts-expect-error 'unknown' is not a valid group
+            group: 'unknown',
+            key: 'greeting',
+        });
+    });
+
+    it('rejects an unknown key within a known group', () => {
+        ilingo.get({
+            group: 'app',
+            // @ts-expect-error 'unknown' is not a key of the `app` group
+            key: 'unknown',
+        });
+    });
+
+    it('rejects a half-correct dotted key', () => {
+        ilingo.get({
+            group: 'app',
+            // @ts-expect-error 'nested.unknown' is not a key
+            key: 'nested.unknown',
+        });
+    });
+
+    it('requires `count` for an explicit @plural leaf', () => {
+        // OK with count.
+        ilingo.get({ group: 'cart', key: 'items', count: 1 });
+
+        // @ts-expect-error count is required for plural keys
+        ilingo.get({ group: 'cart', key: 'items' });
+    });
+
+    it('requires `count` for a structural plural leaf', () => {
+        ilingo.get({ group: 'cart', key: 'shipping', count: 2 });
+
+        // @ts-expect-error count is required for plural keys
+        ilingo.get({ group: 'cart', key: 'shipping' });
+    });
+
+    it('does not require count for a regular string leaf', () => {
+        // No count needed when leaf is plain string.
+        ilingo.get({ group: 'app', key: 'greeting' });
+    });
+});
+
+describe('Ilingo — no generic preserves backward compat (loose typing)', () => {
+    const ilingo = new Ilingo();
+
+    it('accepts arbitrary string groups + keys when no catalog is supplied', () => {
+        // Without a generic, the API is intentionally loose.
+        ilingo.get({ group: 'whatever', key: 'really.anything' });
+        ilingo.get({ group: 'whatever', key: 'really.anything', count: 5 });
+    });
+});
+
+describe('defineCatalog — preserves narrow inference', () => {
+    it('keeps per-key literal types instead of widening to string', () => {
+        const c = defineCatalog({
+            en: { app: { greeting: 'Hi' } },
+        });
+
+        // `defineCatalog` carries a `const` generic — keys stay literal,
+        // not widened to plain `string`. We assert by reaching for a
+        // specific key path that would otherwise be `string` typed.
+        expectTypeOf<keyof typeof c>().toEqualTypeOf<'en'>();
+        expectTypeOf<keyof (typeof c)['en']>().toEqualTypeOf<'app'>();
+        expectTypeOf<keyof (typeof c)['en']['app']>().toEqualTypeOf<'greeting'>();
+    });
+});

--- a/packages/ilingo/test/vitest.config.ts
+++ b/packages/ilingo/test/vitest.config.ts
@@ -3,6 +3,13 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        // Type-level tests (`*.spec-d.ts`) are run by `vitest --typecheck` —
+        // see the `test:types` package script. They are intentionally not
+        // part of the default run because typecheck is slow.
+        typecheck: {
+            tsconfig: './tsconfig.json',
+            include: ['test/unit/**/*.spec-d.ts'],
+        },
         coverage: {
             provider: 'v8',
             include: ['src/**/*.{ts,tsx,js,jsx}'],

--- a/packages/ilingo/tsconfig.json
+++ b/packages/ilingo/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../tsconfig.json",
     "compilerOptions": {
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "types": ["node"]
     },
     "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

Implements **phase 4** of the roadmap ([.agents/plans/004-type-safe-keys.md](.agents/plans/004-type-safe-keys.md)). Closes #898; advances the [#907](https://github.com/tada5hi/ilingo/issues/907) umbrella.

The \`Ilingo\` class becomes generic in the catalog shape. The compiler refuses unknown groups, unknown keys (including dotted paths), and plural-key calls that forget \`count\`. No runtime change — types are erased.

\`\`\`ts
const catalog = defineCatalog({
    en: { app: { greeting: 'Hi {{name}}' },
          cart: { items: { '@plural': { one: '..', other: '..' } } } },
    de: { ... },
});
const ilingo = new Ilingo<typeof catalog>();
await ilingo.get({ group: 'app',  key: 'greeting' });           // OK
await ilingo.get({ group: 'app',  key: 'unknown' });            // ❌ type error
await ilingo.get({ group: 'app',  key: 'nested.deep.leaf' });   // OK — dotted paths inferred
await ilingo.get({ group: 'cart', key: 'items' });              // ❌ type error — count required
await ilingo.get({ group: 'cart', key: 'items', count: 1 });    // OK
\`\`\`

## Type helpers

In \`packages/ilingo/src/types.ts\`:
- \`AnyGroups<C>\`, \`Groups<C>\` — pick any locale's group map, enumerate names.
- \`LeafAt<T, K>\` — walk a dotted path through a typed object.
- \`DottedPaths<T>\` — enumerate dotted leaf paths. Short-circuits to plain \`string\` on open-shape inputs so the default \`LocalesRecord\` reduces to a \`string\`-typed key (otherwise it would collapse to \`never\` and break existing untyped callers).
- \`Key<C, G>\`, \`IsPluralKey<C, G, K>\`, \`GetParams<C, G, K>\` — the per-call parameter shape. Conditional on \`IsPluralKey\` for the \`count\` field (required for plural leaves, optional for string leaves).

## defineCatalog

\`defineCatalog<const T>(catalog: T): T\` is a runtime identity function with a TS 5+ const-generic. It captures the catalog literal without callers having to sprinkle \`as const\`.

## Scope decisions (worth flagging)

- **\`IStore\` left non-generic.** The catalog flows through \`Ilingo<C>\` only. Custom store implementations stay simple at the cost of not propagating the catalog into store-level types. Easy to revisit if a concrete use case appears.
- **Vue composable not made generic in this PR.** \`useTranslation\` uses the injected (loosely typed) \`Ilingo\` instance; making it catalog-aware needs either an explicit type-param plumbed through every call site or i18next-style module augmentation. Tracked as a follow-up.
- **\`merge()\` signature**: typed as \`Ilingo<LocalesRecord>\` so any concrete \`Ilingo<C>\` can merge with the default loose instance.
- **\`packages/ilingo/tsconfig.json\`** gains \`types: ["node"]\` so tsc-based typecheckers (vitest \`--typecheck\`, vue-tsc) recognise the bare \`process.env.NODE_ENV\` reference in \`module.ts\`. tsdown's build was already happy.

## Tests

- \`test/unit/types.spec-d.ts\` (new) — 10 compile-time tests via \`expectTypeOf\` and \`@ts-expect-error\`. Cover: flat / nested / unknown groups + keys, plural-key \`count\` requirement (both \`@plural\` and structural forms), \`defineCatalog\` narrow inference, no-generic loose-typing backward compat.
- Run via \`npm run test:types --workspace=packages/ilingo\` (vitest \`--typecheck --typecheck.only\` against \`*.spec-d.ts\`). Default \`npm test\` does not include them.
- All 84 existing runtime tests pass unchanged.

## Test plan

- [x] \`npm run build\` — all 4 workspaces
- [x] \`npm run lint\` — clean
- [x] \`npm run test\` — 84 runtime tests pass
- [x] \`npm run test:types --workspace=packages/ilingo\` — 10 type tests, no errors

## Docs

- \`packages/ilingo/README.md\` — new "Type-safe keys" section
- \`.agents/architecture.md\` — new design decision; file structure adds \`catalog.ts\`
- \`.agents/structure.md\` — \`catalog.ts\`, new exported types, new \`*.spec-d.ts\`
- \`.agents/testing.md\` — new type-test entry plus how to run it
- \`.agents/plans/004-type-safe-keys.md\` — In review, acceptance boxes checked
- \`.agents/plans/README.md\` — phase 4 row flipped

## Roadmap

After merging:

- [Phase 5 — Vue ergonomics (#900, #901, #902)](.agents/plans/005-vue-ergonomics.md) — now benefits from \`Catalog\` generic if/when we make the composable catalog-aware
- [Phase 6 — DX + custom formatters (#903–#906)](.agents/plans/006-dx-and-loader.md) — unchanged