### PR TITLE
feat(vue): slot-aware ITranslateT, v-t directive, scoped catalogs

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -152,6 +152,20 @@ If `onMissingKey` is not configured, the built-in default warns once per `(reque
 
 `@ilingo/vuelidate` chains this: it calls `applyInstallInput`, then ensures its own `Store` (a `MemoryStore` pre-loaded with EN/DE/FR/ES validator translations) is registered if none is present yet.
 
+### Slot-aware rendering — `<ITranslateT>` + `tokenize()`
+
+`<ITranslateT>` extends `<ITranslate>` with **slot placeholders**: a message can contain `{slot}` markers (single curly) alongside the usual `{{var}}` interpolations (double curly). The component renders each slot from a named scoped slot, producing inline VNodes (links, bold runs, icons) without splitting the message across keys.
+
+Core support lives in `packages/ilingo/src/utils/template.ts` as a separate `tokenize(str): TemplateToken[]` function. Tokens are `text` / `var` / `slot`. The plain `template()` function continues to return a string (used by `Ilingo.format`); the tokenizer is for renderers that produce structured output. `template()` and `tokenize()` share no state — they're parallel parsers over the same syntax.
+
+### `v-t` directive
+
+`packages/vue/src/directives/t.ts` exposes a `createVTDirective(instance, localeRef)` factory. Registered by `install()` on the Vue app under the name `t`, opt-out via `Options.directives: false`. The directive writes the translation to the element's `textContent` and uses `watchEffect` to track the locale Ref — locale changes update the element in place, no remount required. A stop-handle is stashed on the element via a `Symbol.for('ilingo.v-t.stop')` key so the directive can cancel the effect on unmount and re-subscribe on update.
+
+### Scoped catalogs — `useScopedCatalog`
+
+Creates a fresh `Ilingo` instance with a `MemoryStore` for the scoped messages registered *first* (scoped strings win), then re-adds every store from the parent instance (non-scoped keys still fall through). Calls `provideIlingo(scoped)` so the component subtree sees the scoped instance via plain `useTranslation`. Returns `{ instance, t }` for same-component use, since Vue's provide can't reach the current setup's own injections.
+
 ## Data Flow
 
 ```
@@ -197,7 +211,7 @@ packages/ilingo/src/
 │   ├── locale.ts            ← bcp47Parents, resolveLocaleChain
 │   ├── identify.ts          ← isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord, PLURAL_MARKER
 │   ├── formatters.ts        ← FormatterRegistry, parseFormatterOptions, parseModifier, Formatter type
-│   ├── template.ts          ← {{var}} + {{var, formatter(opts)}} substitution
+│   ├── template.ts          ← {{var}} + {{var, formatter(opts)}} substitution; tokenize() for slot-aware renderers
 │   └── language/            ← isBCP47LanguageCode + CLDR data
 └── config/                  ← typed input shape
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -19,11 +19,16 @@
 ## Workflow
 
 - After source changes, run `npm run lint` (top-level) and `npm run build` (top-level or `--workspace=packages/<pkg>`) before declaring a task done.
-- **Keep docs in sync with code.** Every change that touches an observable surface — new public API, behavior change, new config field, new file in `src/`, new test spec — updates the affected docs in the same commit:
-  - User-facing: `packages/<pkg>/README.md` **and** the corresponding page under `docs/src/guide/` or `docs/src/integrations/`. The README is the GitHub landing page; the docs site is the canonical published reference — both must stay accurate.
-  - Agent docs: `.agents/architecture.md` for orchestration / data-flow / patterns; `.agents/structure.md` for the file tree; `.agents/testing.md` for new specs; this file for new conventions or tooling.
-  - Plan files in `.agents/plans/` flip their status from Ready → In review → Done as the work moves through PRs.
-  - Exceptions: pure internal refactors with no observable change, and one-line bug fixes that don't change semantics. Use judgment.
+- **Keep docs in sync with code — every layer, every commit.** Any change that touches an observable surface (new public API, behavior change, new config field, new file in `src/`, new test spec) updates **all three** doc layers in the *same* commit. Shipping a public surface that's documented in only one layer is a real review-blocking gap, not a follow-up.
+  1. **Package READMEs** (`packages/<pkg>/README.md`) — GitHub landing page. Update for any new public symbol or contract change in that package.
+  2. **VitePress docs** (`docs/src/guide/*.md` for conceptual / cross-package material; `docs/src/integrations/*.md` for per-integration usage — Vue, fs, Vuelidate). The canonical published reference at the docs site. Cross-link guide ↔ integration pages where it helps the reader.
+  3. **Agent docs** — `.agents/architecture.md` (orchestration / data-flow / patterns), `.agents/structure.md` (file tree), `.agents/testing.md` (new specs), this file (new conventions or tooling).
+
+  Plan files in `.agents/plans/` flip status Ready → In review → Done as the work moves through PRs.
+
+  **Verification step before declaring done**: for every new public symbol exported from `src/index.ts`, grep both `packages/*/README.md` AND `docs/src/**/*.md`. Both must reference it. If they don't, the work isn't done.
+
+  Exceptions: pure internal refactors with no observable change, and one-line bug fixes that don't change semantics. Use judgment.
 - When adding a new public symbol, re-export it from the package's `src/index.ts` — that file is the public-API contract.
 - When changing an `IStore` method signature, update both adapters (`MemoryStore`, `FSStore`) in the same commit; they share the port interface.
 - When adding a new package, register it in `release-please-config.json` and in the root `README.md` package list. monoship will publish it on the next release if its `version` is not on the registry.

--- a/.agents/plans/005-vue-ergonomics.md
+++ b/.agents/plans/005-vue-ergonomics.md
@@ -1,6 +1,6 @@
 # Phase 5 — Vue ergonomics
 
-**Status**: Blocked by Phase 2 (uses fallback + missing-key handler) and ideally Phase 4 (so composables can be generic in the catalog).
+**Status**: In review (branch `feat/vue-ergonomics`).
 **Tracks**: [#900](https://github.com/tada5hi/ilingo/issues/900), [#901](https://github.com/tada5hi/ilingo/issues/901), [#902](https://github.com/tada5hi/ilingo/issues/902).
 
 Brings `@ilingo/vue` to feature parity with vue-i18n's most-used Vue surface: component interpolation, the `v-t` directive, and scoped catalogs.
@@ -36,9 +36,23 @@ Brings `@ilingo/vue` to feature parity with vue-i18n's most-used Vue surface: co
 
 ## Acceptance
 
-- [ ] `<ITranslateT path="app.welcome"><template #user><strong>Peter</strong></template></ITranslateT>` renders the strong inline.
-- [ ] `v-t` updates the DOM when `setLocale()` is called, without remounting the element.
-- [ ] Scoped messages added in a `<Modal>` do not leak to the surrounding page after the modal unmounts (asserted via `injectIlingo` reading back).
+- [x] `<ITranslateT path="app.welcome"><template #cta><strong>get started</strong></template></ITranslateT>` renders the strong inline. Asserted in `component-t.spec.ts` (`mixes vars and slots in a single message`).
+- [x] `v-t` reactively updates when the injected locale Ref changes — element identity preserved (no remount). Asserted in `directive-t.spec.ts` (`reactively updates when the injected locale Ref changes — without remounting`).
+- [x] Scoped messages added in a `<Modal>` do not leak to a sibling component. Asserted in `scoped-catalog.spec.ts` (`does not leak the scoped messages to a sibling component`).
+- [x] `useScopedCatalog` returns `{ instance, t }` for same-component use because Vue's provide/inject can't reach the current setup's own provides — the descendant path uses plain `useTranslation`. Both paths covered by tests.
+- [x] `Options.directives: false` opts out of `v-t` registration. Covered.
+
+## Design notes (recorded during implementation)
+
+- The template tokenizer lives in **core** (`packages/ilingo/src/utils/template.ts`) so non-Vue renderers (e.g. a future React adapter) can reuse it. Plain `template()` continues to return a string for `Ilingo.format`; `tokenize()` is a parallel parser for VNode-producing renderers.
+- `<ITranslateT>` is a `.ts` render-function component (no `.vue` SFC) — interleaving text/VNode children is more direct in a render function than in template syntax.
+- The `v-t` directive captures the `Ilingo` instance and locale `Ref` at install-time via a `createVTDirective(instance, localeRef)` factory. The closure means directive lifecycle hooks (which run outside setup) can still reach the orchestrator.
+- A `Symbol.for('ilingo.v-t.stop')` is stashed on the element to hold the `watchEffect` stop-handle, so re-bindings and unmounts can cancel the effect cleanly.
+- `useScopedCatalog` could not be wired to mutate the current component's own injection — Vue's API doesn't expose that. Returning a same-component `t` shorthand is the pragmatic alternative and matches vue-i18n's `useI18n` pattern.
+
+## Follow-up out of scope
+
+- Catalog-aware generics in the Vue composables (`useTranslation<typeof catalog>(...)`, `<ITranslateT<typeof catalog>>`). Phase 4 left this for later because the Vue side needs either module augmentation (`declare module '@ilingo/vue' { interface IlingoCatalog { ... } }`) or per-call generics, both of which deserve their own design pass.
 
 ## Why this order
 

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -8,7 +8,7 @@ Phased roadmap for ilingo, sequenced to land coherent waves of work rather than 
 | 2     | [002-resolution-path.md](002-resolution-path.md)       | In review   | #895, #897, #899                |
 | 3     | [003-intl-formatters.md](003-intl-formatters.md)       | In review   | #896                            |
 | 4     | [004-type-safe-keys.md](004-type-safe-keys.md)         | In review   | #898                            |
-| 5     | [005-vue-ergonomics.md](005-vue-ergonomics.md)         | Blocked by 2| #900, #901, #902                |
+| 5     | [005-vue-ergonomics.md](005-vue-ergonomics.md)         | In review   | #900, #901, #902                |
 | 6     | [006-dx-and-loader.md](006-dx-and-loader.md)           | Blocked by 5| #903, #904, #905, #906          |
 
 ## How to use these

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -56,7 +56,7 @@ src/
     ├── locale.ts             # bcp47Parents, resolveLocaleChain
     ├── identify.ts           # PLURAL_MARKER + isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord
     ├── formatters.ts         # FormatterRegistry, parseFormatterOptions, parseModifier, Formatter type
-    ├── template.ts           # {{var}} + {{var, formatter(opts)}} interpolation
+    ├── template.ts           # {{var}} + {{var, formatter(opts)}} interpolation + tokenize() for slot-aware renderers (Vue)
     └── language/
         ├── index.ts
         ├── module.ts         # isBCP47LanguageCode
@@ -94,16 +94,26 @@ test/
 
 ```
 src/
-├── index.ts                  # install(), applyInstallInput(), default Plugin export, ITranslate re-export
-├── component.vue             # <ITranslate> component
+├── index.ts                  # install(), applyInstallInput(), default Plugin export,
+│                             #   ITranslate / ITranslateT re-export, v-t directive registration
+├── component.vue             # <ITranslate> component (plain {{var}} substitution)
+├── component-t.ts            # <ITranslateT> — slot-aware renderer (uses tokenize from core)
 ├── helpers.ts
-├── types.ts                  # Options, GetContextReactive, etc.
+├── types.ts                  # Options (incl. directives?: boolean), GetContextReactive, DataMaybeRef
+├── directives/
+│   └── t.ts                  # createVTDirective(): reactive locale-tracking v-t directive
 └── composables/
     ├── index.ts
     ├── instance.ts           # provideIlingo / injectIlingo / injectIlingoSafe
     ├── locale.ts             # provideLocale / injectLocale / injectLocaleSafe (Ref<string>)
     ├── use-translation.ts    # useTranslation(ctx): Ref<string> via computedAsync
+    ├── use-scoped-catalog.ts # useScopedCatalog({ messages }) → { instance, t } + provides scoped Ilingo
     └── utils.ts              # extractReactiveData
+test/                         # happy-dom + @vue/test-utils via vitest
+└── unit/
+    ├── component-t.spec.ts   # <ITranslateT> rendering (slots, vars, fragments, error paths)
+    ├── directive-t.spec.ts   # v-t directive (string/object bindings, reactive locale, opt-out)
+    └── scoped-catalog.spec.ts# useScopedCatalog (same-component t, descendant provide, no-leak, fallback)
 playground/                   # local Vue app for manual testing (vite dev)
 index.html, vite.config.js    # vite dev entry
 ```

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -47,6 +47,17 @@ data/
 └── language/{en,de,fr}/form.{js,ts,json}   # cross-extension loader fixtures
 ```
 
+### `packages/vue/test/`
+
+```
+unit/
+├── component-t.spec.ts         # <ITranslateT> — slot rendering, vars, fragments, error paths
+├── directive-t.spec.ts         # v-t directive — string/object bindings, reactive locale, opt-out
+└── scoped-catalog.spec.ts      # useScopedCatalog — same-component t, descendant provide, no-leak, fallback
+```
+
+The Vue package uses **happy-dom** for the DOM environment and **@vue/test-utils**'s `mount` + `flushPromises` for component rendering. Plain `nextTick` is not enough — `useTranslation` resolves through `computedAsync`, which needs the microtask queue flushed.
+
 ### `packages/fs/test/`
 
 ```

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -49,7 +49,7 @@ data/
 
 ### `packages/vue/test/`
 
-```
+```text
 unit/
 ├── component-t.spec.ts         # <ITranslateT> — slot rendering, vars, fragments, error paths
 ├── directive-t.spec.ts         # v-t directive — string/object bindings, reactive locale, opt-out

--- a/docs/src/guide/templates.md
+++ b/docs/src/guide/templates.md
@@ -75,3 +75,36 @@ Placeholders also accept inline modifiers — see [Formatters](./formatters).
 ```typescript
 'You owe {{amount, number(style=currency, currency=EUR)}}'
 ```
+
+## Slot placeholders
+
+Beyond `{{var}}` (double curly braces, substituted from `data`), messages can carry `{slot}` placeholders (single curly braces) that are filled by named scoped slots in renderer-aware components. The plain `template()` function leaves `{slot}` markers as literal text — only slot-aware renderers like `<ITranslateT>` consume them.
+
+```typescript
+'Hi {{user}}, please {cta} to continue.'
+//   ^^^^^^         ^^^^^
+//   data var       slot
+```
+
+Use cases: dropping a `<a>` tag, icon, or bold run into the middle of a translated sentence without splitting the message across keys.
+
+See [Vue integration](../integrations/vue#itranslate-t-slot-aware-interpolation) for the consumer-side syntax.
+
+## `tokenize()` — for renderers
+
+For renderers that produce non-string output (VNodes, JSX, etc.), the core exposes a `tokenize(str): TemplateToken[]` helper that parses a message into `text` / `var` / `slot` tokens. This is what `<ITranslateT>` uses internally; the same primitive lets any future framework adapter walk the same AST.
+
+```typescript
+import { tokenize } from 'ilingo';
+
+tokenize('Hi {{user}}, please {cta} now.');
+// [
+//   { kind: 'text', value: 'Hi ' },
+//   { kind: 'var', name: 'user' },
+//   { kind: 'text', value: ', please ' },
+//   { kind: 'slot', name: 'cta' },
+//   { kind: 'text', value: ' now.' },
+// ]
+```
+
+`tokenize` and `template` are parallel parsers over the same syntax — `template` returns a substituted string for `Ilingo.format`'s common case; `tokenize` returns tokens for structured renderers.

--- a/docs/src/integrations/vue.md
+++ b/docs/src/integrations/vue.md
@@ -80,6 +80,69 @@ For inline use:
 
 `path` is `group.key`. The component is auto-registered by the plugin.
 
+## `<ITranslateT>` — slot-aware interpolation
+
+For messages that need inline HTML or component fragments (links, bold runs, icons), `<ITranslateT>` extends `<ITranslate>` with **slot placeholders**. Single-curly `{slot}` markers in the message are filled by named scoped slots:
+
+```vue
+<template>
+    <ITranslateT path="app.welcome" :data="{ user: 'Peter' }">
+        <template #cta>
+            <a href="/start">get started</a>
+        </template>
+    </ITranslateT>
+    <!-- → <span>Hi Peter, please <a href="/start">get started</a> to continue.</span> -->
+</template>
+```
+
+Message: `"Hi {{user}}, please {cta} to continue."`. The `{{var}}` placeholders still resolve from `data`; `{slot}` placeholders pull from named scoped slots.
+
+- Default wrapper element is `<span>`; override with `tag="p"`, `tag="div"`, etc. Pass `tag=""` to render a fragment with no wrapper.
+- Unfilled slot placeholders stay as literal `{slot}` text — never throws.
+- Reacts to `path` prop changes (no stale group/key after a dynamic flip).
+
+## `v-t` directive
+
+For elements whose entire `textContent` is a single translation, the `v-t` directive avoids the wrapping component:
+
+```vue
+<template>
+    <p v-t="'app.greeting'"></p>
+    <p v-t="{ path: 'app.greet', data: { name: 'Peter' } }"></p>
+    <p v-t="{ group: 'cart', key: 'items', count: 3 }"></p>
+</template>
+```
+
+The directive writes the translation to `el.textContent` and reacts to locale changes — element identity is preserved (no remount on locale flip). In-flight lookups are cancelled when the binding or locale changes again, so a stale translation can't clobber a newer one.
+
+Registered globally by `install()`. Opt out per-app:
+
+```typescript
+install(app, { store, directives: false });
+```
+
+## `useScopedCatalog` — per-component message scope
+
+Some components (modals, embedded widgets, marketing sections) ship their own strings. `useScopedCatalog` creates a fresh `Ilingo` whose stores resolve scoped messages first, then fall back to the parent app's stores:
+
+```vue
+<script setup>
+import { useScopedCatalog, useTranslation } from '@ilingo/vue';
+
+// Use `t` in the SAME component — Vue's provide/inject can't reach
+// the current setup's own provides.
+const { t } = useScopedCatalog({
+    messages: {
+        en: { modal: { greeting: 'Welcome to the modal!' } },
+    },
+});
+
+const greeting = t({ group: 'modal', key: 'greeting' });
+</script>
+```
+
+Descendant components can use plain `useTranslation` — they receive the scoped instance via inject. Siblings outside the subtree continue to see the parent's stores. On unmount, the scoped instance becomes unreachable and is garbage-collected.
+
 ## Accessing the locale
 
 ```vue

--- a/package-lock.json
+++ b/package-lock.json
@@ -1483,6 +1483,109 @@
             "resolved": "packages/vuelidate",
             "link": true
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@jest/diff-sequences": {
             "version": "30.0.1",
             "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
@@ -1742,6 +1845,13 @@
                 "win32"
             ]
         },
+        "node_modules/@one-ini/wasm": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@oxc-project/types": {
             "version": "0.132.0",
             "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
@@ -1750,6 +1860,17 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@quansync/fs": {
@@ -3069,6 +3190,23 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/@vitejs/plugin-vue": {
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.7.tgz",
+            "integrity": "sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rolldown/pluginutils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "vue": "^3.2.25"
+            }
+        },
         "node_modules/@vitest/expect": {
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
@@ -3483,6 +3621,27 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@vue/test-utils": {
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.10.tgz",
+            "integrity": "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-beautify": "^1.14.9",
+                "vue-component-type-helpers": "^3.0.0"
+            },
+            "peerDependencies": {
+                "@vue/compiler-dom": "3.x",
+                "@vue/server-renderer": "3.x",
+                "vue": "3.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/server-renderer": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@vuelidate/core": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@vuelidate/core/-/core-2.0.3.tgz",
@@ -3740,6 +3899,16 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/abbrev": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/acorn": {
@@ -4350,6 +4519,16 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/compare-func": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
@@ -4360,6 +4539,24 @@
                 "array-ify": "^1.0.0",
                 "dot-prop": "^5.1.0"
             }
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/config-chain/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/conventional-changelog-angular": {
             "version": "8.3.1",
@@ -4725,11 +4922,70 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/ebec": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/ebec/-/ebec-2.3.0.tgz",
             "integrity": "sha512-bt+0tSL7223VU3PSVi0vtNLZ8pO1AfWolcPPMk2a/a5H+o/ZU9ky0n3A0zhrR4qzJTN61uPsGIO4ShhOukdzxA==",
             "license": "MIT"
+        },
+        "node_modules/editorconfig": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+            "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@one-ini/wasm": "0.1.1",
+                "commander": "^10.0.0",
+                "minimatch": "^9.0.1",
+                "semver": "^7.5.3"
+            },
+            "bin": {
+                "editorconfig": "bin/editorconfig"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/editorconfig/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/editorconfig/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/ejs": {
             "version": "5.0.1",
@@ -5508,6 +5764,36 @@
                 }
             }
         },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -5712,6 +5998,34 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/happy-dom": {
+            "version": "15.11.7",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-15.11.7.tgz",
+            "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^4.5.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-mimetype": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/happy-dom/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/has-flag": {
@@ -6128,6 +6442,22 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/jiti": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -6135,6 +6465,117 @@
             "license": "MIT",
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/js-beautify": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-chain": "^1.1.13",
+                "editorconfig": "^1.0.4",
+                "glob": "^10.4.2",
+                "js-cookie": "^3.0.5",
+                "nopt": "^7.2.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-beautify/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-beautify/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/js-beautify/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/js-beautify/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/js-beautify/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/js-beautify/node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+            "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/js-tokens": {
@@ -6927,6 +7368,22 @@
                 "node": ">=18"
             }
         },
+        "node_modules/nopt": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -7521,6 +7978,13 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/proxy-from-env": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -8097,6 +8561,22 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/stringify-entities": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -8113,6 +8593,20 @@
             }
         },
         "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -9437,6 +9931,13 @@
                 }
             }
         },
+        "node_modules/vue-component-type-helpers": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.1.tgz",
+            "integrity": "sha512-pu58kqxmVyEH6VfNYW1UyEfR3XAnJ27ZXT3yzXxxpjLxVzAbyC35Zk/nm/RMs7ijWnJNSd9fWkeex2OhUsx3MA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/vue-eslint-parser": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
@@ -9489,12 +9990,32 @@
                 "defaults": "^1.0.3"
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
             "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -9540,6 +10061,25 @@
             }
         },
         "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -9680,9 +10220,14 @@
             "version": "5.0.0",
             "license": "MIT",
             "devDependencies": {
+                "@vitejs/plugin-vue": "^6.0.3",
+                "@vue/test-utils": "^2.4.6",
                 "@vueuse/core": "^14.1.0",
+                "cross-env": "^10.1.0",
+                "happy-dom": "^15.11.0",
                 "ilingo": "^5.0.0",
                 "vite": "^7.3.1",
+                "vitest": "^4.1.5",
                 "vue": "^3.5.26"
             },
             "engines": {

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -23,6 +23,7 @@ Ilingo is a lightweight library for translation and internationalization.
   - [Missing-key handler](#missing-key-handler)
   - [Formatters](#formatters)
   - [Type-safe keys](#type-safe-keys)
+  - [Slot placeholders & `tokenize()`](#slot-placeholders--tokenize)
 - [Store](#store)
   - [Memory](#memory-store)
   - [FileSystem](#fs-store)
@@ -466,6 +467,25 @@ await ilingo.get({ group: 'cart',  key: 'items', count: 1 });  // OK
 Inference is structural, derived from the union of locales. Keep all locales aligned to the same shape and the inferred `Key<C, G>` is the natural set of leaf paths. Diverging locales widen the union but never break compilation.
 
 `new Ilingo()` (no generic) preserves today's loose typing — `group: string, key: string` are accepted. The generic is opt-in.
+
+### Slot placeholders & `tokenize()`
+
+In addition to `{{var}}` data placeholders (and modifier syntax), messages can carry `{slot}` markers (single curly braces) for renderers that produce structured output rather than a string. The core `tokenize(str)` helper parses a message into `text` / `var` / `slot` tokens:
+
+```typescript
+import { tokenize } from 'ilingo';
+
+tokenize('Hi {{user}}, please {cta} now.');
+// [
+//   { kind: 'text', value: 'Hi ' },
+//   { kind: 'var', name: 'user' },
+//   { kind: 'text', value: ', please ' },
+//   { kind: 'slot', name: 'cta' },
+//   { kind: 'text', value: ' now.' },
+// ]
+```
+
+`tokenize()` and `template()` are parallel parsers — `template()` returns a substituted string (used by `Ilingo.format`); `tokenize()` returns tokens for VNode-producing renderers (e.g. `@ilingo/vue`'s `<ITranslateT>`). Plain `Ilingo.get()` always returns a string, so `{slot}` markers survive into the output unless a slot-aware renderer consumes them.
 
 ## Store
 

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -61,7 +61,7 @@ export class Ilingo<C extends LocalesRecord = LocalesRecord> {
      * modifiers. Built-in entries: `number`, `date`, `list` (each backed
      * by the matching `Intl.*Format`, memoised by `(locale, options)`).
      */
-    public readonly formatters: FormatterRegistry;
+    public formatters: FormatterRegistry;
 
     /**
      * Per-instance set of `(locale, group, key)` triples that have already
@@ -94,6 +94,40 @@ export class Ilingo<C extends LocalesRecord = LocalesRecord> {
     }
 
     // ----------------------------------------------------
+
+    /**
+     * Build a new `Ilingo` that inherits this instance's configuration
+     * (locale, fallback, missing-key handler), shares its formatter
+     * registry, and includes its stores in order. The new instance is
+     * independent — mutating its `stores` does not affect the parent —
+     * but the shared `formatters` registry means custom formatters
+     * registered on either side are visible to both.
+     *
+     * `overrides.store`, when provided, becomes the **first** store in
+     * the new instance (resolved before any inherited store). Other
+     * overrides replace the corresponding inherited config field.
+     *
+     * Designed for consumers that need a scoped variant of an existing
+     * orchestrator — e.g. `@ilingo/vue`'s `useScopedCatalog`.
+     */
+    clone(overrides: ConfigInput = {}): Ilingo {
+        const child = new Ilingo({
+            store: overrides.store,
+            locale: overrides.locale ?? this.locale,
+            fallback: 'fallback' in overrides ? overrides.fallback : this.fallback,
+            onMissingKey: overrides.onMissingKey ?? this.onMissingKey,
+        });
+        // Inherit stores in order (overrides.store, if any, was already added
+        // first by the constructor — appending parent's keeps the precedence).
+        for (const store of this.stores) {
+            child.stores.add(store);
+        }
+        // Share the formatter registry so custom registrations on the parent
+        // are honoured. Trade-off: mutations on either side are visible to
+        // both. Callers that need isolation should construct manually.
+        child.formatters = this.formatters;
+        return child;
+    }
 
     merge(instance: Ilingo<LocalesRecord>) {
         const ownEntries = Array.from(this.stores.values());

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -114,8 +114,12 @@ export class Ilingo<C extends LocalesRecord = LocalesRecord> {
         const child = new Ilingo({
             store: overrides.store,
             locale: overrides.locale ?? this.locale,
+            // Use `in`-check (not ??) so explicit `undefined` clears the
+            // inherited value. Matches the `fallback` handling above —
+            // both nullable config fields treat "field present in overrides"
+            // as intent to replace, even when the new value is undefined.
             fallback: 'fallback' in overrides ? overrides.fallback : this.fallback,
-            onMissingKey: overrides.onMissingKey ?? this.onMissingKey,
+            onMissingKey: 'onMissingKey' in overrides ? overrides.onMissingKey : this.onMissingKey,
         });
         // Inherit stores in order (overrides.store, if any, was already added
         // first by the constructor — appending parent's keeps the precedence).

--- a/packages/ilingo/src/utils/template.ts
+++ b/packages/ilingo/src/utils/template.ts
@@ -17,6 +17,69 @@ export interface TemplateContext {
 const DEFAULT_REGEX = /\{\{\s*([^,}]+?)(?:\s*,\s*([^}]+?))?\s*\}\}/g;
 
 /**
+ * Tokens emitted by `tokenize()` for slot-aware rendering (e.g. Vue's
+ * `<ITranslateT>` component).
+ *
+ * - `text`: literal substring between placeholders.
+ * - `var`:  `{{name}}` or `{{name, modifier(opts)}}`. The orchestrator
+ *           replaces these with `data[name]` (optionally piped through
+ *           a formatter); slot renderers do the same.
+ * - `slot`: `{slot-name}` (single curly braces). Slot renderers fill
+ *           these from a named scoped slot; plain `template()` leaves
+ *           them as literal text (no slot-aware substitution).
+ */
+export type TextToken = { kind: 'text', value: string };
+export type VarToken = {
+    kind: 'var',
+    name: string,
+    modifierExpression?: string,
+};
+export type SlotToken = { kind: 'slot', name: string };
+export type TemplateToken = TextToken | VarToken | SlotToken;
+
+// `{{...}}` for vars (with optional modifier) OR `{ident}` for slots.
+// Slot identifier is restricted to a JS-ish identifier so an inline JSON
+// snippet or hand-written `{` in prose doesn't get hijacked.
+const TOKEN_REGEX =    /\{\{\s*([^,}]+?)(?:\s*,\s*([^}]+?))?\s*\}\}|\{\s*([A-Za-z_][A-Za-z0-9_-]*)\s*\}/g;
+
+/**
+ * Parse `str` into an interleaved sequence of text / var / slot tokens.
+ *
+ * Designed for renderers that produce VNodes (or other non-string
+ * structures): the plain `template()` function still returns a string
+ * for the common case.
+ */
+export function tokenize(str: string): TemplateToken[] {
+    const tokens: TemplateToken[] = [];
+    let lastIndex = 0;
+    // `replace()` exposes match index via the named-callback signature.
+    // `matchAll` is cleaner here.
+    for (const match of str.matchAll(TOKEN_REGEX)) {
+        const start = match.index ?? 0;
+        if (start > lastIndex) {
+            tokens.push({ kind: 'text', value: str.slice(lastIndex, start) });
+        }
+
+        const [, varName, modifierExpression, slotName] = match;
+        if (typeof slotName === 'string') {
+            tokens.push({ kind: 'slot', name: slotName });
+        } else if (typeof varName === 'string') {
+            const token: TemplateToken = { kind: 'var', name: varName.trim() };
+            if (typeof modifierExpression === 'string') {
+                token.modifierExpression = modifierExpression.trim();
+            }
+            tokens.push(token);
+        }
+
+        lastIndex = start + match[0].length;
+    }
+    if (lastIndex < str.length) {
+        tokens.push({ kind: 'text', value: str.slice(lastIndex) });
+    }
+    return tokens;
+}
+
+/**
  * Substitute `{{var}}` placeholders. With a `TemplateContext`, also supports
  * modifier syntax: `{{var, modifier}}` and `{{var, modifier(opts)}}`.
  *

--- a/packages/ilingo/test/unit/resolution.spec.ts
+++ b/packages/ilingo/test/unit/resolution.spec.ts
@@ -402,4 +402,64 @@ describe('Ilingo — resolution path', () => {
             expect(await ilingo.get({ group: 'app', key: 'hi' })).toEqual('from store 1');
         });
     });
+
+    describe('Ilingo.clone() — config override semantics', () => {
+        it('inherits parent config when overrides are omitted', async () => {
+            const parent = new Ilingo({
+                store: new MemoryStore({ data: { de: { app: { hi: 'Hallo' } } } }),
+                locale: 'de',
+                fallback: 'de',
+            });
+
+            const child = parent.clone();
+
+            // pt-BR has no data; parent's `fallback: 'de'` should be inherited
+            // so the lookup finds the German translation.
+            expect(await child.get({ group: 'app', key: 'hi', locale: 'pt-BR' }))
+                .toEqual('Hallo');
+        });
+
+        it('overrides.fallback === undefined clears the inherited fallback', async () => {
+            const parent = new Ilingo({
+                store: new MemoryStore({
+                    data: {
+                        de: { app: { hi: 'Hallo' } },
+                        en: { app: { hi: 'Hello' } },
+                    },
+                }),
+                locale: 'en',
+                fallback: 'de',
+            });
+
+            // Explicit `undefined` should clear the inherited 'de' fallback,
+            // so a pt-BR lookup walks BCP-47 parents then ends at the
+            // default 'en' (not at 'de').
+            const child = parent.clone({ fallback: undefined });
+
+            expect(await child.get({ group: 'app', key: 'hi', locale: 'pt-BR' }))
+                .toEqual('Hello');
+        });
+
+        it('overrides.onMissingKey === undefined clears the inherited handler', () => {
+            // Regression: clone() previously used `??` for onMissingKey,
+            // so passing `undefined` couldn't restore the default warn-once
+            // behaviour. Fixed to use `in`-check like `fallback`.
+            const parentHandler = vi.fn(() => 'PARENT');
+            const parent = new Ilingo({
+                store: new MemoryStore({ data: {} }),
+                onMissingKey: parentHandler,
+            });
+
+            const child = parent.clone({ onMissingKey: undefined });
+
+            // Internal check: the child should NOT carry the parent's handler.
+            // Reach into the protected field via type cast (this is a
+            // test-only invariant assertion — runtime behaviour is what
+            // matters, but the field-level check makes the fix obvious).
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect((child as any).onMissingKey).toBeUndefined();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect((parent as any).onMissingKey).toBe(parentHandler);
+        });
+    });
 });

--- a/packages/ilingo/test/unit/utils/template.spec.ts
+++ b/packages/ilingo/test/unit/utils/template.spec.ts
@@ -5,15 +5,83 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { describe, it, expect } from "vitest";
-import {template} from "../../../src";
+import { describe, it, expect } from 'vitest';
+import { template, tokenize } from '../../../src';
 
-describe('src/utils/template', () => {
+describe('src/utils/template — string substitution', () => {
     it('should replace str in template', () => {
-        let str = template('Hi {{name}}!', {name: 'Peter'});
+        let str = template('Hi {{name}}!', { name: 'Peter' });
         expect(str).toEqual('Hi Peter!');
 
         str = template('Hi {{name}}!', {});
         expect(str).toEqual('Hi {{name}}!');
-    })
-})
+    });
+});
+
+describe('src/utils/template — tokenize()', () => {
+    it('returns a single text token for plain strings', () => {
+        expect(tokenize('hello world')).toEqual([
+            { kind: 'text', value: 'hello world' },
+        ]);
+    });
+
+    it('returns an empty array for an empty string', () => {
+        expect(tokenize('')).toEqual([]);
+    });
+
+    it('tokenises a single {{var}}', () => {
+        expect(tokenize('Hi {{name}}!')).toEqual([
+            { kind: 'text', value: 'Hi ' },
+            { kind: 'var', name: 'name' },
+            { kind: 'text', value: '!' },
+        ]);
+    });
+
+    it('captures the modifier expression on a var token', () => {
+        expect(tokenize('You owe {{amount, number(currency=EUR)}}')).toEqual([
+            { kind: 'text', value: 'You owe ' },
+            { kind: 'var', name: 'amount', modifierExpression: 'number(currency=EUR)' },
+        ]);
+    });
+
+    it('tokenises a single {slot}', () => {
+        expect(tokenize('Click {link} to continue')).toEqual([
+            { kind: 'text', value: 'Click ' },
+            { kind: 'slot', name: 'link' },
+            { kind: 'text', value: ' to continue' },
+        ]);
+    });
+
+    it('interleaves vars and slots', () => {
+        expect(tokenize('Hi {{name}}, click {action} now')).toEqual([
+            { kind: 'text', value: 'Hi ' },
+            { kind: 'var', name: 'name' },
+            { kind: 'text', value: ', click ' },
+            { kind: 'slot', name: 'action' },
+            { kind: 'text', value: ' now' },
+        ]);
+    });
+
+    it('does not mistake {{var}} for {slot} (double braces win)', () => {
+        const tokens = tokenize('{{count}}');
+        expect(tokens).toEqual([{ kind: 'var', name: 'count' }]);
+    });
+
+    it('leaves malformed slot syntax as literal text', () => {
+        // Not a valid identifier: contains spaces / starts with digit.
+        expect(tokenize('See { not valid }')).toEqual([
+            { kind: 'text', value: 'See { not valid }' },
+        ]);
+        expect(tokenize('See {1abc}')).toEqual([
+            { kind: 'text', value: 'See {1abc}' },
+        ]);
+    });
+
+    it('accepts kebab-case slot names', () => {
+        expect(tokenize('Click {sign-up-link}!')).toEqual([
+            { kind: 'text', value: 'Click ' },
+            { kind: 'slot', name: 'sign-up-link' },
+            { kind: 'text', value: '!' },
+        ]);
+    });
+});

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -88,6 +88,61 @@ app.mount('#app');
 </template>
 ```
 
+## `<ITranslateT>` — slot-aware interpolation
+
+`<ITranslateT>` lets a message string carry **slot placeholders** alongside the usual `{{var}}` interpolations. Each `{slot}` placeholder in the message is filled by a named scoped slot — drop arbitrary VNodes (links, icons, bold runs) inline without splitting the message across multiple keys.
+
+Message: `"Hi {{user}}, please {cta} to continue."`
+
+```vue
+<ITranslateT path="app.welcome" :data="{ user: 'Peter' }">
+    <template #cta>
+        <a href="/start">get started</a>
+    </template>
+</ITranslateT>
+<!-- → <span>Hi Peter, please <a href="/start">get started</a> to continue.</span> -->
+```
+
+- Rendered tag: `<span>` by default. Override with `tag="p"` etc.; pass `tag=""` to render a fragment with no wrapper.
+- Unfilled slot placeholders stay as literal `{slot}` text (no throw).
+- `{{var}}` placeholders that have no matching `data` key stay as literal `{{var}}`.
+
+## `v-t` directive
+
+`v-t` writes the translation into the element's `textContent` and reacts to locale changes without remounting the element.
+
+```vue
+<p v-t="'app.greeting'"></p>
+
+<p v-t="{ path: 'app.greet', data: { name: 'Peter' } }"></p>
+
+<p v-t="{ group: 'cart', key: 'items', count: 3 }"></p>
+```
+
+The directive is registered globally during `install()`. Opt out per-app via `install(app, { store, directives: false })`.
+
+## `useScopedCatalog` — per-component message scope
+
+Some components (modals, embedded widgets, marketing sections) carry their own strings. `useScopedCatalog` creates an `Ilingo` instance whose stores resolve scoped messages first, then fall back to the parent app's stores. The scoped instance is provided to descendants — siblings outside the component still see the parent's stores.
+
+```vue
+<script setup>
+import { useScopedCatalog, useTranslation } from '@ilingo/vue';
+
+// Returns { instance, t } — use `t` inside the same component because
+// Vue's provide/inject can't reach the current setup's own provides.
+const { t } = useScopedCatalog({
+    messages: {
+        en: { modal: { greeting: 'Welcome to the modal!' } },
+    },
+});
+
+const greeting = t({ group: 'modal', key: 'greeting' });
+</script>
+```
+
+Descendants can use plain `useTranslation` — they get the scoped instance via inject. On unmount, Vue's provides become unreachable and the scoped instance is garbage-collected.
+
 ## License
 
 Made with 💚

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,7 +28,9 @@
         "build:types": "vue-tsc --declaration --emitDeclarationOnly -p tsconfig.build.json",
         "build": "npm run build:js && npm run build:types",
         "lint": "eslint",
-        "lint:fix": "npm run lint -- --fix"
+        "lint:fix": "npm run lint -- --fix",
+        "test": "cross-env NODE_ENV=test vitest --config test/vitest.config.ts --run",
+        "test:coverage": "cross-env NODE_ENV=test vitest --config test/vitest.config.ts --run --coverage"
     },
     "engines": {
         "node": ">=22.0.0"
@@ -50,9 +52,14 @@
     },
     "homepage": "https://github.com/tada5hi/ilingo#readme",
     "devDependencies": {
+        "@vitejs/plugin-vue": "^6.0.3",
+        "@vue/test-utils": "^2.4.6",
         "@vueuse/core": "^14.1.0",
+        "cross-env": "^10.1.0",
+        "happy-dom": "^15.11.0",
         "ilingo": "^5.0.0",
         "vite": "^7.3.1",
+        "vitest": "^4.1.5",
         "vue": "^3.5.26"
     },
     "peerDependencies": {

--- a/packages/vue/src/component-t.ts
+++ b/packages/vue/src/component-t.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { tokenize } from 'ilingo';
+import type { PropType, VNodeChild } from 'vue';
+import { 
+    computed, 
+    defineComponent, 
+    h, 
+    unref, 
+} from 'vue';
+import { useTranslation } from './composables';
+import type { DataMaybeRef } from './types';
+
+/**
+ * `<ITranslateT>` — slot-aware translation component.
+ *
+ * The message can contain `{slot}` placeholders alongside the usual
+ * `{{var}}` interpolations. Slots are filled by named scoped slots on the
+ * component, so consumers can drop arbitrary VNodes (links, icons, bold
+ * runs, …) inline without splitting the message across multiple keys.
+ *
+ * ```vue
+ * <ITranslateT path="app.welcome" :data="{ user: 'Peter' }">
+ *     <template #cta>
+ *         <a href="/start">get started</a>
+ *     </template>
+ * </ITranslateT>
+ * ```
+ *
+ * With `app.welcome = "Hi {{user}}, click {cta} to continue."`, the
+ * rendered output is `<span>Hi Peter, click <a href="/start">get started</a> to continue.</span>`.
+ *
+ * Element tag is `<span>` by default. Override via the `tag` prop
+ * (e.g. `tag="p"`); pass `tag=""` to render a fragment with no wrapper.
+ */
+export const ITranslateT = defineComponent({
+    name: 'ITranslateT',
+    props: {
+        path: { type: String, required: true },
+        data: { type: Object as PropType<DataMaybeRef> },
+        locale: { type: String },
+        count: { type: [Number, Object] as PropType<number | { value: number }> },
+        tag: { type: String, default: 'span' },
+    },
+    setup(props, { slots }) {
+        const { group, key } = parsePath(props.path);
+
+        const text = useTranslation({
+            group,
+            key,
+            data: props.data,
+            locale: props.locale,
+            count: props.count as never,
+        });
+
+        const tokens = computed(() => tokenize(text.value));
+
+        return () => {
+            const children: VNodeChild[] = [];
+            for (const token of tokens.value) {
+                if (token.kind === 'text') {
+                    children.push(token.value);
+                } else if (token.kind === 'var') {
+                    const raw = props.data?.[token.name];
+                    children.push(
+                        typeof raw === 'undefined' ? `{{${token.name}}}` : String(unref(raw)),
+                    );
+                } else {
+                    const slotFn = slots[token.name];
+                    if (slotFn) {
+                        // Spread the slot's VNodes inline.
+                        for (const node of slotFn()) {
+                            children.push(node);
+                        }
+                    } else {
+                        children.push(`{${token.name}}`);
+                    }
+                }
+            }
+            if (!props.tag) {
+                // `tag=""` renders the children without a wrapper element.
+                return children;
+            }
+            return h(props.tag, children);
+        };
+    },
+});
+
+function parsePath(path: string): { group: string, key: string } {
+    const index = path.indexOf('.');
+    if (index === -1) {
+        throw new SyntaxError(
+            `[ilingo] <ITranslateT path="${path}"> requires a "group.key" path.`,
+        );
+    }
+    return {
+        group: path.slice(0, index),
+        key: path.slice(index + 1),
+    };
+}

--- a/packages/vue/src/component-t.ts
+++ b/packages/vue/src/component-t.ts
@@ -91,9 +91,16 @@ export const ITranslateT = defineComponent({
                     // props.data in case the value is a Ref that wasn't
                     // unwrapped by extractReactiveData (defensive).
                     const raw = props.data?.[token.name];
-                    children.push(
-                        typeof raw === 'undefined' ? `{{${token.name}}}` : String(unref(raw)),
-                    );
+                    if (typeof raw === 'undefined') {
+                        // Preserve the FULL original placeholder, including any
+                        // modifier expression — dropping it would silently
+                        // mutate the literal text shown when data is missing.
+                        children.push(token.modifierExpression ?
+                            `{{${token.name}, ${token.modifierExpression}}}` :
+                            `{{${token.name}}}`);
+                    } else {
+                        children.push(String(unref(raw)));
+                    }
                 } else {
                     const slotFn = slots[token.name];
                     if (slotFn) {
@@ -117,7 +124,8 @@ export const ITranslateT = defineComponent({
 
 function parsePath(path: string): { group: string, key: string } {
     const index = path.indexOf('.');
-    if (index === -1) {
+    // Reject missing dot, leading dot (empty group), and trailing dot (empty key).
+    if (index <= 0 || index >= path.length - 1) {
         throw new SyntaxError(
             `[ilingo] <ITranslateT path="${path}"> requires a "group.key" path.`,
         );

--- a/packages/vue/src/component-t.ts
+++ b/packages/vue/src/component-t.ts
@@ -5,15 +5,18 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { computedAsync } from '@vueuse/core';
 import { tokenize } from 'ilingo';
 import type { PropType, VNodeChild } from 'vue';
-import { 
-    computed, 
-    defineComponent, 
-    h, 
-    unref, 
+import {
+    computed,
+    defineComponent,
+    h,
+    unref,
 } from 'vue';
-import { useTranslation } from './composables';
+import { injectIlingo } from './composables/instance';
+import { injectLocale } from './composables/locale';
+import { extractReactiveData } from './composables/utils';
 import type { DataMaybeRef } from './types';
 
 /**
@@ -44,19 +47,34 @@ export const ITranslateT = defineComponent({
         path: { type: String, required: true },
         data: { type: Object as PropType<DataMaybeRef> },
         locale: { type: String },
-        count: { type: [Number, Object] as PropType<number | { value: number }> },
+        count: { type: Number },
         tag: { type: String, default: 'span' },
     },
     setup(props, { slots }) {
-        const { group, key } = parsePath(props.path);
+        const instance = injectIlingo();
+        const localeRef = injectLocale();
 
-        const text = useTranslation({
-            group,
-            key,
-            data: props.data,
-            locale: props.locale,
-            count: props.count as never,
-        });
+        // Reactive to `props.path` — re-parses if the parent flips the path
+        // mid-flight. Throws on a path without a dot, matching <ITranslate>.
+        // Eagerly validated at setup so a malformed initial path fails on
+        // mount rather than asynchronously on first render.
+        parsePath(props.path);
+        const parsed = computed(() => parsePath(props.path));
+
+        const text = computedAsync(
+            async () => {
+                const { group, key } = parsed.value;
+                const value = await instance.get({
+                    group,
+                    key,
+                    data: props.data ? extractReactiveData(props.data) : undefined,
+                    locale: props.locale ?? localeRef.value,
+                    count: props.count,
+                });
+                return value ?? `${group}.${key}`;
+            },
+            '',
+        );
 
         const tokens = computed(() => tokenize(text.value));
 
@@ -66,6 +84,12 @@ export const ITranslateT = defineComponent({
                 if (token.kind === 'text') {
                     children.push(token.value);
                 } else if (token.kind === 'var') {
+                    // `{{var}}` placeholders are normally substituted by
+                    // Ilingo.format() before tokenize sees the message; this
+                    // branch handles the leftover case where data was missing
+                    // a key, so the placeholder survived. Re-check
+                    // props.data in case the value is a Ref that wasn't
+                    // unwrapped by extractReactiveData (defensive).
                     const raw = props.data?.[token.name];
                     children.push(
                         typeof raw === 'undefined' ? `{{${token.name}}}` : String(unref(raw)),
@@ -98,8 +122,5 @@ function parsePath(path: string): { group: string, key: string } {
             `[ilingo] <ITranslateT path="${path}"> requires a "group.key" path.`,
         );
     }
-    return {
-        group: path.slice(0, index),
-        key: path.slice(index + 1),
-    };
+    return { group: path.slice(0, index), key: path.slice(index + 1) };
 }

--- a/packages/vue/src/composables/index.ts
+++ b/packages/vue/src/composables/index.ts
@@ -7,4 +7,5 @@
 
 export * from './instance';
 export * from './locale';
+export * from './use-scoped-catalog';
 export * from './use-translation';

--- a/packages/vue/src/composables/instance.ts
+++ b/packages/vue/src/composables/instance.ts
@@ -19,7 +19,7 @@ const IlingoSymbol = Symbol.for('Ilingo');
 
 export function provideIlingo(
     ilingo: Ilingo,
-    app: App,
+    app?: App,
 ) {
     if (typeof app === 'undefined') {
         provide(IlingoSymbol, ilingo);

--- a/packages/vue/src/composables/use-scoped-catalog.ts
+++ b/packages/vue/src/composables/use-scoped-catalog.ts
@@ -6,8 +6,8 @@
  */
 
 import { computedAsync } from '@vueuse/core';
-import type { LocalesRecord } from 'ilingo';
-import { Ilingo, MemoryStore } from 'ilingo';
+import type { Ilingo, LocalesRecord } from 'ilingo';
+import { MemoryStore } from 'ilingo';
 import type { Ref } from 'vue';
 import { unref } from 'vue';
 import type { GetContextReactive } from '../types';
@@ -60,16 +60,16 @@ export function useScopedCatalog(options: { messages: LocalesRecord }): UseScope
     const parent = injectIlingo();
     const locale = injectLocale();
 
-    const instance = new Ilingo({ store: new MemoryStore({ data: options.messages }) });
-    // Parent stores resolve *after* the scoped catalog — scoped messages
-    // win, but anything not scoped still falls back to the parent's stores.
-    // Note: the orchestrator's own `instance.locale` default is intentionally
-    // left at LOCALE_DEFAULT — callers always pass `locale` from the
-    // injected Vue Ref (via `t()` here, or `useTranslation` on descendants),
-    // so the instance default is never consulted.
-    for (const store of parent.stores) {
-        instance.stores.add(store);
-    }
+    // `parent.clone()` inherits the parent's locale + fallback +
+    // onMissingKey and shares the formatter registry, so the scoped
+    // instance honours every config knob the parent set up. The scoped
+    // store is registered *first* (so its translations win), then the
+    // parent's stores fall through for anything not scoped.
+    //
+    // Note: the orchestrator's own `instance.locale` default is irrelevant
+    // here — callers always pass `locale` from the injected Vue Ref (via
+    // `t()` below, or `useTranslation` on descendants).
+    const instance = parent.clone({ store: new MemoryStore({ data: options.messages }) });
 
     // Make the scoped instance available to descendants. Vue's
     // provide is component-local, so siblings outside this subtree are

--- a/packages/vue/src/composables/use-scoped-catalog.ts
+++ b/packages/vue/src/composables/use-scoped-catalog.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { computedAsync } from '@vueuse/core';
+import type { LocalesRecord } from 'ilingo';
+import { Ilingo, MemoryStore } from 'ilingo';
+import type { Ref } from 'vue';
+import { unref } from 'vue';
+import type { GetContextReactive } from '../types';
+import { injectIlingo, provideIlingo } from './instance';
+import { injectLocale } from './locale';
+import { extractReactiveData } from './utils';
+
+export interface UseScopedCatalogResult {
+    /** The scoped `Ilingo` instance — exposed for advanced cases. */
+    instance: Ilingo;
+    /**
+     * `useTranslation`-shaped lookup bound to the scoped instance. Use this
+     * inside the same setup that called `useScopedCatalog` — provide/inject
+     * is hierarchical, so a same-component `useTranslation` would still see
+     * the parent instance.
+     */
+    t(ctx: GetContextReactive): Ref<string>;
+}
+
+/**
+ * Scope a per-component message catalog. Creates a fresh `Ilingo` instance,
+ * prepends a `MemoryStore` of `messages` (so scoped strings win), and
+ * re-adds the parent's stores so non-scoped keys still fall through.
+ *
+ * Two ways to consume the scope:
+ *
+ * 1. **Same component** — use the returned `t` shorthand. Vue's
+ *    provide/inject can't reach the current setup's own provides, so
+ *    `useTranslation` in the same component would still see the parent.
+ * 2. **Descendant components** — `useScopedCatalog` also calls
+ *    `provideIlingo(scoped)`, so any child can just call `useTranslation`
+ *    and get the scoped instance.
+ *
+ * No teardown is needed: Vue's provides are component-scoped, so the
+ * scoped instance becomes unreachable on unmount and GC'd naturally.
+ *
+ * @example
+ *     // Same-component shorthand:
+ *     const { t } = useScopedCatalog({
+ *         messages: { en: { modal: { greeting: 'Scoped hello' } } },
+ *     });
+ *     const greeting = t({ group: 'modal', key: 'greeting' });
+ *
+ *     // Descendants — child components just call useTranslation:
+ *     <ScopedRoot>
+ *         <ChildThatCallsUseTranslation />
+ *     </ScopedRoot>
+ */
+export function useScopedCatalog(options: { messages: LocalesRecord }): UseScopedCatalogResult {
+    const parent = injectIlingo();
+    const locale = injectLocale();
+
+    const instance = new Ilingo({ store: new MemoryStore({ data: options.messages }) });
+    // Parent stores resolve *after* the scoped catalog — scoped messages
+    // win, but anything not scoped still falls back to the parent's stores.
+    for (const store of parent.stores) {
+        instance.stores.add(store);
+    }
+    instance.setLocale(parent.getLocale());
+
+    // Make the scoped instance available to descendants. Vue's
+    // provide is component-local, so siblings outside this subtree are
+    // unaffected — and the scope evaporates on unmount.
+    provideIlingo(instance);
+
+    function t(ctx: GetContextReactive): Ref<string> {
+        const defaultValue = `${ctx.group}.${ctx.key}`;
+        return computedAsync(
+            async () => {
+                const value = await instance.get({
+                    locale: ctx.locale ?? locale.value,
+                    data: ctx.data ? extractReactiveData(ctx.data) : undefined,
+                    group: ctx.group,
+                    key: ctx.key,
+                    count: unref(ctx.count),
+                });
+                return value || defaultValue;
+            },
+            defaultValue,
+        );
+    }
+
+    return { instance, t };
+}

--- a/packages/vue/src/composables/use-scoped-catalog.ts
+++ b/packages/vue/src/composables/use-scoped-catalog.ts
@@ -63,10 +63,13 @@ export function useScopedCatalog(options: { messages: LocalesRecord }): UseScope
     const instance = new Ilingo({ store: new MemoryStore({ data: options.messages }) });
     // Parent stores resolve *after* the scoped catalog — scoped messages
     // win, but anything not scoped still falls back to the parent's stores.
+    // Note: the orchestrator's own `instance.locale` default is intentionally
+    // left at LOCALE_DEFAULT — callers always pass `locale` from the
+    // injected Vue Ref (via `t()` here, or `useTranslation` on descendants),
+    // so the instance default is never consulted.
     for (const store of parent.stores) {
         instance.stores.add(store);
     }
-    instance.setLocale(parent.getLocale());
 
     // Make the scoped instance available to descendants. Vue's
     // provide is component-local, so siblings outside this subtree are

--- a/packages/vue/src/directives/t.ts
+++ b/packages/vue/src/directives/t.ts
@@ -92,15 +92,30 @@ export function createVTDirective(
     function apply(el: ElementWithStop, value: VTBinding) {
         el[STOP_KEY]?.();
         const ctx = resolveBinding(value);
-        el[STOP_KEY] = watchEffect(async () => {
-            const text = await instance.get({
-                group: ctx.group,
-                key: ctx.key,
-                data: ctx.data,
-                count: ctx.count,
-                locale: ctx.locale ?? localeRef.value,
-            });
-            el.textContent = text ?? `${ctx.group}.${ctx.key}`;
+        el[STOP_KEY] = watchEffect((onCleanup) => {
+            // Track the locale Ref synchronously so the watcher's dependency
+            // set is established BEFORE the async hop. Reading it later (after
+            // await) wouldn't be tracked.
+            const localeOverride = ctx.locale ?? localeRef.value;
+
+            // Cancel-on-stale: if `apply()` re-runs (binding change, locale
+            // change, unmount) while a prior `instance.get(...)` is still
+            // in-flight, mark it cancelled so its eventual resolution can't
+            // clobber a newer translation.
+            let cancelled = false;
+            onCleanup(() => { cancelled = true; });
+
+            (async () => {
+                const text = await instance.get({
+                    group: ctx.group,
+                    key: ctx.key,
+                    data: ctx.data,
+                    count: ctx.count,
+                    locale: localeOverride,
+                });
+                if (cancelled) return;
+                el.textContent = text ?? `${ctx.group}.${ctx.key}`;
+            })();
         });
     }
 

--- a/packages/vue/src/directives/t.ts
+++ b/packages/vue/src/directives/t.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Ilingo } from 'ilingo';
+import type { Directive, Ref } from 'vue';
+import { watchEffect } from 'vue';
+
+/**
+ * Binding accepted by the `v-t` directive.
+ *
+ * - `string` — shorthand for `{ path }`. Parsed as `"group.key"`.
+ * - `{ path, data?, locale?, count? }` — explicit context.
+ * - `{ group, key, data?, locale?, count? }` — alternative explicit form.
+ */
+export type VTBindingDataMap = Record<string, string | number>;
+
+export type VTBindingPath = {
+    path: string,
+    data?: VTBindingDataMap,
+    locale?: string,
+    count?: number,
+};
+
+export type VTBindingGroupKey = {
+    group: string,
+    key: string,
+    data?: VTBindingDataMap,
+    locale?: string,
+    count?: number,
+};
+
+export type VTBinding = string | VTBindingPath | VTBindingGroupKey;
+
+type Resolved = {
+    group: string,
+    key: string,
+    data?: Record<string, string | number>,
+    locale?: string,
+    count?: number,
+};
+
+function resolveBinding(value: VTBinding): Resolved {
+    if (typeof value === 'string') {
+        return splitPath(value);
+    }
+    if ('path' in value) {
+        const { group, key } = splitPath(value.path);
+        return {
+            group,
+            key,
+            data: value.data,
+            locale: value.locale,
+            count: value.count,
+        };
+    }
+    return value;
+}
+
+function splitPath(path: string): { group: string, key: string } {
+    const index = path.indexOf('.');
+    if (index === -1) {
+        throw new SyntaxError(
+            `[ilingo] v-t="${path}" requires a "group.key" path.`,
+        );
+    }
+    return { group: path.slice(0, index), key: path.slice(index + 1) };
+}
+
+/**
+ * Factory for the `v-t` directive. Bound to the install-time `Ilingo`
+ * instance and locale ref so the directive can run outside of a component
+ * setup context.
+ *
+ * The element's `textContent` is updated reactively when the locale
+ * changes or the binding value changes — no remount required.
+ *
+ * Marker symbol on the element holds the watchEffect's stop handle so it
+ * can be cancelled on unmount or re-bound on update.
+ */
+const STOP_KEY = Symbol.for('ilingo.v-t.stop');
+
+type ElementWithStop = HTMLElement & { [STOP_KEY]?: () => void };
+
+export function createVTDirective(
+    instance: Ilingo,
+    localeRef: Ref<string>,
+): Directive<HTMLElement, VTBinding> {
+    function apply(el: ElementWithStop, value: VTBinding) {
+        el[STOP_KEY]?.();
+        const ctx = resolveBinding(value);
+        el[STOP_KEY] = watchEffect(async () => {
+            const text = await instance.get({
+                group: ctx.group,
+                key: ctx.key,
+                data: ctx.data,
+                count: ctx.count,
+                locale: ctx.locale ?? localeRef.value,
+            });
+            el.textContent = text ?? `${ctx.group}.${ctx.key}`;
+        });
+    }
+
+    return {
+        mounted(el, binding) {
+            apply(el as ElementWithStop, binding.value);
+        },
+        updated(el, binding) {
+            apply(el as ElementWithStop, binding.value);
+        },
+        unmounted(el) {
+            (el as ElementWithStop)[STOP_KEY]?.();
+        },
+    };
+}

--- a/packages/vue/src/directives/t.ts
+++ b/packages/vue/src/directives/t.ts
@@ -62,7 +62,8 @@ function resolveBinding(value: VTBinding): Resolved {
 
 function splitPath(path: string): { group: string, key: string } {
     const index = path.indexOf('.');
-    if (index === -1) {
+    // Reject missing dot, leading dot (empty group), and trailing dot (empty key).
+    if (index <= 0 || index >= path.length - 1) {
         throw new SyntaxError(
             `[ilingo] v-t="${path}" requires a "group.key" path.`,
         );
@@ -106,15 +107,23 @@ export function createVTDirective(
             onCleanup(() => { cancelled = true; });
 
             (async () => {
-                const text = await instance.get({
-                    group: ctx.group,
-                    key: ctx.key,
-                    data: ctx.data,
-                    count: ctx.count,
-                    locale: localeOverride,
-                });
-                if (cancelled) return;
-                el.textContent = text ?? `${ctx.group}.${ctx.key}`;
+                try {
+                    const text = await instance.get({
+                        group: ctx.group,
+                        key: ctx.key,
+                        data: ctx.data,
+                        count: ctx.count,
+                        locale: localeOverride,
+                    });
+                    if (cancelled) return;
+                    el.textContent = text ?? `${ctx.group}.${ctx.key}`;
+                } catch {
+                    // A rejected store / formatter shouldn't propagate as an
+                    // unhandled promise rejection. Degrade to the same
+                    // group.key fallback we use when get() returns undefined.
+                    if (cancelled) return;
+                    el.textContent = `${ctx.group}.${ctx.key}`;
+                }
             })();
         });
     }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -9,6 +9,8 @@ import { Ilingo } from 'ilingo';
 import type { App, Plugin } from 'vue';
 import { ref } from 'vue';
 import ITranslate from './component.vue';
+import { ITranslateT } from './component-t';
+import { createVTDirective } from './directives/t';
 import {
     injectIlingoSafe,
     injectLocaleSafe,
@@ -20,7 +22,7 @@ import type { Options } from './types';
 export function applyInstallInput(
     app: App,
     input?: Options | Ilingo,
-) : Ilingo {
+): Ilingo {
     let locale = injectLocaleSafe(app);
     const localeExisted = typeof locale !== 'undefined' && !!locale.value;
     let instance = injectIlingoSafe(app);
@@ -65,15 +67,25 @@ export function applyInstallInput(
     return instance;
 }
 
-export function install(app: App, input: Options | Ilingo) : void {
-    applyInstallInput(app, input);
+export function install(app: App, input?: Options | Ilingo): void {
+    const instance = applyInstallInput(app, input);
 
     app.component('ITranslate', ITranslate);
+    app.component('ITranslateT', ITranslateT);
+
+    const directivesEnabled = !(input && !(input instanceof Ilingo) && input.directives === false);
+    if (directivesEnabled) {
+        const locale = injectLocaleSafe(app)!;
+        app.directive('t', createVTDirective(instance, locale));
+    }
 }
 
-export default { install } satisfies Plugin<Options | Ilingo>;
+export default { install } satisfies Plugin<Options | Ilingo | undefined>;
 
 export { default as ITranslate } from './component.vue';
+export { ITranslateT } from './component-t';
+export { createVTDirective } from './directives/t';
+export type { VTBinding } from './directives/t';
 export * from './composables';
 export * from './types';
 export * from './helpers';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -13,6 +13,7 @@ import { ITranslateT } from './component-t';
 import { createVTDirective } from './directives/t';
 import {
     injectIlingoSafe,
+    injectLocale,
     injectLocaleSafe,
     provideIlingo,
     provideLocale,
@@ -75,7 +76,11 @@ export function install(app: App, input?: Options | Ilingo): void {
 
     const directivesEnabled = !(input && !(input instanceof Ilingo) && input.directives === false);
     if (directivesEnabled) {
-        const locale = injectLocaleSafe(app)!;
+        // applyInstallInput always ensures a locale Ref is provided to the
+        // app, so the non-safe injectLocale is justified here. If that
+        // contract ever changes, this throws instead of producing a
+        // misbehaving directive.
+        const locale = injectLocale(app);
         app.directive('t', createVTDirective(instance, locale));
     }
 }

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -10,7 +10,14 @@ import type { MaybeRef } from 'vue';
 
 export type Options = {
     store: IStore,
-    locale?: string
+    locale?: string,
+    /**
+     * When `false`, the `v-t` directive is NOT registered globally on the
+     * Vue app. Useful for apps that prefer the explicit `<ITranslate>` /
+     * `<ITranslateT>` components, or that already use `v-t` for something
+     * else. Default: `true`.
+     */
+    directives?: boolean,
 };
 
 export type DataMaybeRef = Record<string, MaybeRef<string | number>>;

--- a/packages/vue/test/unit/component-t.spec.ts
+++ b/packages/vue/test/unit/component-t.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { mount, flushPromises } from "@vue/test-utils";
+import { Ilingo, MemoryStore } from 'ilingo';
+import { h, nextTick } from 'vue';
+import { describe, expect, it } from 'vitest';
+import { ITranslateT, install } from '../../src';
+
+function makeApp(messages: Record<string, Record<string, Record<string, unknown>>>) {
+    return {
+        install(app: import('vue').App) {
+            install(app, {
+                store: new MemoryStore({ data: messages }),
+                locale: 'en',
+            });
+        },
+    };
+}
+
+describe('<ITranslateT> — slot-aware interpolation (#900)', () => {
+    it('renders a string-only message in a <span>', async () => {
+        const wrapper = mount(ITranslateT, {
+            props: { path: 'app.hi' },
+            global: {
+                plugins: [makeApp({ en: { app: { hi: 'Hello there' } } })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.element.tagName).toEqual('SPAN');
+        expect(wrapper.text()).toEqual('Hello there');
+    });
+
+    it('substitutes {{var}} placeholders from `data`', async () => {
+        const wrapper = mount(ITranslateT, {
+            props: { path: 'app.greet', data: { name: 'Peter' } },
+            global: {
+                plugins: [makeApp({ en: { app: { greet: 'Hi {{name}}!' } } })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.text()).toEqual('Hi Peter!');
+    });
+
+    it('renders named scoped slots inline at their {slot} placeholders', async () => {
+        const wrapper = mount(ITranslateT, {
+            props: { path: 'app.cta' },
+            slots: {
+                cta: () => h('a', { href: '/start' }, 'get started'),
+            },
+            global: {
+                plugins: [makeApp({
+                    en: { app: { cta: 'Please {cta} to continue.' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.text()).toEqual('Please get started to continue.');
+        const a = wrapper.find('a');
+        expect(a.exists()).toBe(true);
+        expect(a.attributes('href')).toEqual('/start');
+    });
+
+    it('mixes vars and slots in a single message', async () => {
+        const wrapper = mount(ITranslateT, {
+            props: { path: 'app.welcome', data: { user: 'Peter' } },
+            slots: {
+                cta: () => h('strong', null, 'get started'),
+            },
+            global: {
+                plugins: [makeApp({
+                    en: {
+                        app: {
+                            welcome: 'Hi {{user}}, please {cta} now.',
+                        },
+                    },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.text()).toEqual('Hi Peter, please get started now.');
+        expect(wrapper.find('strong').exists()).toBe(true);
+    });
+
+    it('leaves an unfilled slot placeholder as literal `{slot}` text', async () => {
+        const wrapper = mount(ITranslateT, {
+            props: { path: 'app.cta' },
+            // no `cta` slot provided
+            global: {
+                plugins: [makeApp({
+                    en: { app: { cta: 'Please {cta} to continue.' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.text()).toEqual('Please {cta} to continue.');
+    });
+
+    it('rejects a path without a group prefix', () => {
+        expect(() => mount(ITranslateT, {
+            props: { path: 'no-dot' },
+            global: {
+                plugins: [makeApp({ en: { app: {} } })],
+            },
+        })).toThrow(/group\.key/);
+    });
+
+    it('renders a fragment with no wrapper when tag=""', async () => {
+        const wrapper = mount({
+            components: { ITranslateT },
+            template: '<div><ITranslateT path="app.hi" tag="" /></div>',
+        }, {
+            global: {
+                plugins: [makeApp({ en: { app: { hi: 'Hello' } } })],
+            },
+        });
+
+        await flushPromises();
+        // No nested <span> — the text sits directly under <div>.
+        expect(wrapper.find('span').exists()).toBe(false);
+        expect(wrapper.text()).toEqual('Hello');
+    });
+});
+
+// Helper local to this file — installs Ilingo into the test root using the
+// real `install()` entry point exercised by consumers.
+declare module 'vue' {
+    interface ComponentCustomOptions {}
+}

--- a/packages/vue/test/unit/component-t.spec.ts
+++ b/packages/vue/test/unit/component-t.spec.ts
@@ -5,9 +5,9 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { mount, flushPromises } from "@vue/test-utils";
-import { Ilingo, MemoryStore } from 'ilingo';
-import { h, nextTick } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import { MemoryStore } from 'ilingo';
+import { defineComponent, h } from 'vue';
 import { describe, expect, it } from 'vitest';
 import { ITranslateT, install } from '../../src';
 
@@ -114,6 +114,32 @@ describe('<ITranslateT> — slot-aware interpolation (#900)', () => {
         })).toThrow(/group\.key/);
     });
 
+    it('reacts to a dynamic `path` prop (no stale group/key)', async () => {
+        // Regression: an earlier implementation parsed `props.path` once at
+        // setup, so flipping the path after mount left the component stuck
+        // on the original message.
+        const Wrapper = defineComponent({
+            components: { ITranslateT },
+            data() {
+                return { p: 'app.hi' };
+            },
+            template: '<ITranslateT :path="p" data-test="t" />',
+        });
+
+        const wrapper = mount(Wrapper, {
+            global: {
+                plugins: [makeApp({ en: { app: { hi: 'Hello', bye: 'Goodbye' } } })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.text()).toEqual('Hello');
+
+        (wrapper.vm as never as { p: string }).p = 'app.bye';
+        await flushPromises();
+        expect(wrapper.text()).toEqual('Goodbye');
+    });
+
     it('renders a fragment with no wrapper when tag=""', async () => {
         const wrapper = mount({
             components: { ITranslateT },
@@ -131,8 +157,3 @@ describe('<ITranslateT> — slot-aware interpolation (#900)', () => {
     });
 });
 
-// Helper local to this file — installs Ilingo into the test root using the
-// real `install()` entry point exercised by consumers.
-declare module 'vue' {
-    interface ComponentCustomOptions {}
-}

--- a/packages/vue/test/unit/component-t.spec.ts
+++ b/packages/vue/test/unit/component-t.spec.ts
@@ -114,6 +114,37 @@ describe('<ITranslateT> — slot-aware interpolation (#900)', () => {
         })).toThrow(/group\.key/);
     });
 
+    it.each([
+        ['.key'],     // empty group
+        ['group.'],   // empty key
+        ['.'],        // both empty
+    ])('rejects an empty segment in path: %s', (badPath) => {
+        expect(() => mount(ITranslateT, {
+            props: { path: badPath },
+            global: {
+                plugins: [makeApp({ en: { app: {} } })],
+            },
+        })).toThrow(/group\.key/);
+    });
+
+    it('preserves the full original placeholder (incl. modifier) when data is missing', async () => {
+        // Regression: the var-token fallback previously rendered `{{name}}`
+        // even when the original placeholder carried a modifier expression
+        // like `{{amount, number(currency=EUR)}}`. Dropping the modifier
+        // silently mutated the literal text shown for missing data.
+        const wrapper = mount(ITranslateT, {
+            props: { path: 'app.owe', data: {} as never },
+            global: {
+                plugins: [makeApp({
+                    en: { app: { owe: 'You owe {{amount, number(currency=EUR)}}' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.text()).toEqual('You owe {{amount, number(currency=EUR)}}');
+    });
+
     it('reacts to a dynamic `path` prop (no stale group/key)', async () => {
         // Regression: an earlier implementation parsed `props.path` once at
         // setup, so flipping the path after mount left the component stuck

--- a/packages/vue/test/unit/directive-t.spec.ts
+++ b/packages/vue/test/unit/directive-t.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { MemoryStore } from 'ilingo';
+import type { Ref } from 'vue';
+import { defineComponent } from 'vue';
+import { describe, expect, it, vi } from 'vitest';
+import { injectLocale, install } from '../../src';
+
+function plugin(messages: Record<string, unknown>, locale = 'en', options: { directives?: boolean } = {}) {
+    return {
+        install(app: import('vue').App) {
+            install(app, {
+                store: new MemoryStore({ data: messages as never }),
+                locale,
+                directives: options.directives,
+            });
+        },
+    };
+}
+
+describe('v-t directive (#901)', () => {
+    it('updates textContent on a <p v-t="\'group.key\'"> element', async () => {
+        const Wrapper = defineComponent({
+            template: '<p data-test="t" v-t="\'app.hi\'"></p>',
+        });
+
+        const wrapper = mount(Wrapper, {
+            global: { plugins: [plugin({ en: { app: { hi: 'Hello there' } } })] },
+        });
+
+        await flushPromises();
+        expect(wrapper.find('[data-test="t"]').text()).toEqual('Hello there');
+    });
+
+    it('accepts an object binding with data', async () => {
+        const Wrapper = defineComponent({
+            template: '<p data-test="t" v-t="{ path: \'app.greet\', data: { name: \'Peter\' } }"></p>',
+        });
+
+        const wrapper = mount(Wrapper, {
+            global: { plugins: [plugin({ en: { app: { greet: 'Hi {{name}}!' } } })] },
+        });
+
+        await flushPromises();
+        expect(wrapper.find('[data-test="t"]').text()).toEqual('Hi Peter!');
+    });
+
+    it('reactively updates when the injected locale Ref changes — without remounting', async () => {
+        const Wrapper = defineComponent({
+            template: '<p data-test="t" v-t="\'app.hi\'"></p>',
+        });
+
+        let localeRef: Ref<string> | undefined;
+
+        const ProbeRoot = defineComponent({
+            components: { Wrapper },
+            template: '<Wrapper />',
+            setup() {
+                // Capture the injected locale Ref so the test can flip it.
+                localeRef = injectLocale();
+            },
+        });
+
+        const wrapper = mount(ProbeRoot, {
+            global: {
+                plugins: [plugin({
+                    en: { app: { hi: 'Hello' } },
+                    de: { app: { hi: 'Hallo' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        const el = wrapper.find('[data-test="t"]').element as HTMLElement;
+        expect(el.textContent).toEqual('Hello');
+
+        // Element identity captured to assert no remount.
+        const nodeBefore = el;
+
+        localeRef!.value = 'de';
+        await flushPromises();
+
+        const nodeAfter = wrapper.find('[data-test="t"]').element as HTMLElement;
+        expect(nodeAfter).toBe(nodeBefore);              // no remount
+        expect(nodeAfter.textContent).toEqual('Hallo');  // updated
+    });
+
+    it('directives: false opts out of v-t registration', () => {
+        const Wrapper = defineComponent({
+            template: '<p v-t="\'app.hi\'"></p>',
+        });
+
+        // Vue warns when a directive resolution fails but doesn't throw.
+        // Assert by sniffing console.warn.
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        mount(Wrapper, {
+            global: {
+                plugins: [plugin({ en: { app: { hi: 'Hello' } } }, 'en', { directives: false })],
+            },
+        });
+        const messages = warn.mock.calls.map((args) => String(args[0])).join('\n');
+        expect(messages).toMatch(/Failed to resolve directive: t|directive "t"/i);
+        warn.mockRestore();
+    });
+});

--- a/packages/vue/test/unit/directive-t.spec.ts
+++ b/packages/vue/test/unit/directive-t.spec.ts
@@ -91,6 +91,68 @@ describe('v-t directive (#901)', () => {
         expect(nodeAfter.textContent).toEqual('Hallo');  // updated
     });
 
+    it('cancels in-flight lookups on locale change (no stale clobber)', async () => {
+        // Regression: without onCleanup in the watchEffect, a slow `get()`
+        // started under the previous locale could resolve after the locale
+        // had already changed and clobber `textContent` with the stale
+        // translation.
+        const store = new MemoryStore({
+            data: {
+                en: { app: { hi: 'Hello' } },
+                de: { app: { hi: 'Hallo' } },
+            },
+        });
+
+        // Wrap the store to make `get()` artificially slow for 'en' but fast
+        // for 'de'. Without the cancel-on-stale fix, the slow 'en' lookup
+        // would resolve last and win.
+        const originalGet = store.get.bind(store);
+        store.get = async (ctx) => {
+            if (ctx.locale === 'en') {
+                await new Promise((r) => setTimeout(r, 30));
+            }
+            return originalGet(ctx);
+        };
+
+        const ProbeRoot = defineComponent({
+            template: '<p data-test="t" v-t="\'app.hi\'"></p>',
+        });
+
+        let localeRef: Ref<string> | undefined;
+        const ProbeRootWithLocale = defineComponent({
+            components: { ProbeRoot },
+            template: '<ProbeRoot />',
+            setup() {
+                localeRef = injectLocale();
+            },
+        });
+
+        const wrapper = mount(ProbeRootWithLocale, {
+            global: {
+                plugins: [{
+                    install(app: import('vue').App) {
+                        install(app, { store, locale: 'en' });
+                    },
+                }],
+            },
+        });
+
+        // Wait briefly so the initial 'en' lookup has *started* but not yet
+        // resolved (its 30ms delay).
+        await new Promise((r) => setTimeout(r, 5));
+
+        // Flip locale to 'de' while 'en' is still in flight.
+        localeRef!.value = 'de';
+
+        // Let everything settle — the slow 'en' resolution races with the
+        // fast 'de' resolution. With the fix, the cancelled 'en' branch
+        // never writes textContent.
+        await new Promise((r) => setTimeout(r, 80));
+        await flushPromises();
+
+        expect(wrapper.find('[data-test="t"]').text()).toEqual('Hallo');
+    });
+
     it('directives: false opts out of v-t registration', () => {
         const Wrapper = defineComponent({
             template: '<p v-t="\'app.hi\'"></p>',

--- a/packages/vue/test/unit/directive-t.spec.ts
+++ b/packages/vue/test/unit/directive-t.spec.ts
@@ -153,6 +153,38 @@ describe('v-t directive (#901)', () => {
         expect(wrapper.find('[data-test="t"]').text()).toEqual('Hallo');
     });
 
+    it('falls back to group.key when instance.get() rejects', async () => {
+        // Regression: the async IIFE inside the directive's watchEffect
+        // previously had no try/catch; a rejected get() would surface as
+        // an unhandled promise rejection and leave the textContent stale.
+        const failingStore = {
+            async get(): Promise<never> {
+                throw new Error('boom');
+            },
+            async set() { /* noop */ },
+            async getLocales() { return []; },
+        };
+
+        const Wrapper = defineComponent({
+            template: '<p data-test="t" v-t="\'app.hi\'">initial</p>',
+        });
+
+        const wrapper = mount(Wrapper, {
+            global: {
+                plugins: [{
+                    install(app: import('vue').App) {
+                        install(app, { store: failingStore as never, locale: 'en' });
+                    },
+                }],
+            },
+        });
+
+        await flushPromises();
+        // Catches the rejection; falls back to the group.key contract used
+        // when get() returns undefined.
+        expect(wrapper.find('[data-test="t"]').text()).toEqual('app.hi');
+    });
+
     it('directives: false opts out of v-t registration', () => {
         const Wrapper = defineComponent({
             template: '<p v-t="\'app.hi\'"></p>',

--- a/packages/vue/test/unit/scoped-catalog.spec.ts
+++ b/packages/vue/test/unit/scoped-catalog.spec.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { MemoryStore } from 'ilingo';
+import { defineComponent, h } from 'vue';
+import { describe, expect, it } from 'vitest';
+import { install, useScopedCatalog, useTranslation } from '../../src';
+
+function plugin(messages: Record<string, unknown>, locale = 'en') {
+    return {
+        install(app: import('vue').App) {
+            install(app, {
+                store: new MemoryStore({ data: messages as never }),
+                locale,
+            });
+        },
+    };
+}
+
+describe('useScopedCatalog (#902)', () => {
+    it('returns a same-component `t` bound to the scoped instance', async () => {
+        const Modal = defineComponent({
+            template: '<p data-test="modal">{{ text }}</p>',
+            setup() {
+                const { t } = useScopedCatalog({
+                    messages: {
+                        en: { modal: { greeting: 'Scoped hello' } },
+                    },
+                });
+                const text = t({ group: 'modal', key: 'greeting' });
+                return { text };
+            },
+        });
+
+        const wrapper = mount(Modal, {
+            global: {
+                plugins: [plugin({
+                    en: { modal: { greeting: 'Default hello' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.find('[data-test="modal"]').text()).toEqual('Scoped hello');
+    });
+
+    it('propagates the scope to descendant components via provideIlingo', async () => {
+        // Child uses plain `useTranslation` and resolves via the scoped
+        // instance that the parent's useScopedCatalog provided.
+        const Body = defineComponent({
+            template: '<p data-test="body">{{ text }}</p>',
+            setup() {
+                const text = useTranslation({ group: 'modal', key: 'greeting' });
+                return { text };
+            },
+        });
+
+        const Modal = defineComponent({
+            components: { Body },
+            template: '<Body />',
+            setup() {
+                useScopedCatalog({
+                    messages: { en: { modal: { greeting: 'Scoped hello' } } },
+                });
+            },
+        });
+
+        const wrapper = mount(Modal, {
+            global: {
+                plugins: [plugin({
+                    en: { modal: { greeting: 'Default hello' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.find('[data-test="body"]').text()).toEqual('Scoped hello');
+    });
+
+    it('does not leak the scoped messages to a sibling component', async () => {
+        const ModalBody = defineComponent({
+            template: '<p data-test="modal">{{ text }}</p>',
+            setup() {
+                const text = useTranslation({ group: 'modal', key: 'greeting' });
+                return { text };
+            },
+        });
+
+        const Modal = defineComponent({
+            components: { ModalBody },
+            template: '<ModalBody />',
+            setup() {
+                useScopedCatalog({
+                    messages: { en: { modal: { greeting: 'Scoped hello' } } },
+                });
+            },
+        });
+
+        const Sibling = defineComponent({
+            template: '<p data-test="sibling">{{ text }}</p>',
+            setup() {
+                const text = useTranslation({ group: 'modal', key: 'greeting' });
+                return { text };
+            },
+        });
+
+        const Page = defineComponent({
+            components: { Modal, Sibling },
+            template: '<div><Modal /><Sibling /></div>',
+        });
+
+        const wrapper = mount(Page, {
+            global: {
+                plugins: [plugin({
+                    en: { modal: { greeting: 'Default hello' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.find('[data-test="modal"]').text()).toEqual('Scoped hello');
+        // Sibling is OUTSIDE the modal's subtree — sees the parent default.
+        expect(wrapper.find('[data-test="sibling"]').text()).toEqual('Default hello');
+    });
+
+    it('falls back to the parent catalog for keys not in the scope', async () => {
+        const Modal = defineComponent({
+            template: '<p data-test="modal">{{ text }}</p>',
+            setup() {
+                // Only `modal.greeting` is scoped. `app.foo` falls through.
+                const { t } = useScopedCatalog({
+                    messages: { en: { modal: { greeting: 'Scoped hello' } } },
+                });
+                const text = t({ group: 'app', key: 'foo' });
+                return { text };
+            },
+        });
+
+        const wrapper = mount(Modal, {
+            global: {
+                plugins: [plugin({
+                    en: { app: { foo: 'global foo' } },
+                })],
+            },
+        });
+
+        await flushPromises();
+        expect(wrapper.find('[data-test="modal"]').text()).toEqual('global foo');
+    });
+});

--- a/packages/vue/test/unit/scoped-catalog.spec.ts
+++ b/packages/vue/test/unit/scoped-catalog.spec.ts
@@ -6,8 +6,8 @@
  */
 
 import { flushPromises, mount } from '@vue/test-utils';
-import { MemoryStore } from 'ilingo';
-import { defineComponent, h } from 'vue';
+import { Ilingo, MemoryStore } from 'ilingo';
+import { defineComponent } from 'vue';
 import { describe, expect, it } from 'vitest';
 import { install, useScopedCatalog, useTranslation } from '../../src';
 
@@ -126,6 +126,55 @@ describe('useScopedCatalog (#902)', () => {
         expect(wrapper.find('[data-test="modal"]').text()).toEqual('Scoped hello');
         // Sibling is OUTSIDE the modal's subtree — sees the parent default.
         expect(wrapper.find('[data-test="sibling"]').text()).toEqual('Default hello');
+    });
+
+    it('inherits the parent fallback chain', async () => {
+        // Regression: previously useScopedCatalog only copied stores, dropping
+        // the parent's `fallback` config so scoped lookups walked a different
+        // chain than the parent.
+        const Modal = defineComponent({
+            template: '<p data-test="modal">{{ text }}</p>',
+            setup() {
+                const { t } = useScopedCatalog({
+                    messages: { en: { modal: { greeting: 'Scoped hello' } } },
+                });
+                // Request a locale ('ru') that has no data anywhere; with the
+                // parent's `fallback: 'de'` honoured, the chain reaches the
+                // German parent translation. Without it, the lookup would fall
+                // to 'en' (the default) and pick up the wrong message.
+                const text = t({ group: 'app', key: 'farewell', locale: 'ru' });
+                return { text };
+            },
+        });
+
+        // Plugin with a custom `fallback: 'de'` on the parent Ilingo.
+        const PluginWithFallback = {
+            install(app: import('vue').App) {
+                // Build a fresh Ilingo with a custom fallback, then install.
+                // (Manual construction because the helper plugin() above
+                // doesn't expose `fallback`.)
+                const ilingo = new Ilingo({
+                    fallback: 'de',
+                    store: new MemoryStore({
+                        data: {
+                            de: { app: { farewell: 'Tschüss aus DE' } },
+                            en: { app: { farewell: 'Bye from EN' } },
+                        },
+                    }),
+                    locale: 'en',
+                });
+                install(app, ilingo);
+            },
+        };
+
+        const wrapper = mount(Modal, {
+            global: { plugins: [PluginWithFallback] },
+        });
+
+        await flushPromises();
+        // 'ru' → fallback 'de' → 'Tschüss aus DE'. If fallback were dropped,
+        // we'd see 'Bye from EN'.
+        expect(wrapper.find('[data-test="modal"]').text()).toEqual('Tschüss aus DE');
     });
 
     it('falls back to the parent catalog for keys not in the scope', async () => {

--- a/packages/vue/test/vitest.config.ts
+++ b/packages/vue/test/vitest.config.ts
@@ -1,0 +1,14 @@
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    plugins: [vue()],
+    test: {
+        environment: 'happy-dom',
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,vue}'],
+        },
+    },
+});


### PR DESCRIPTION
## Summary

Implements **phase 5** of the roadmap ([.agents/plans/005-vue-ergonomics.md](.agents/plans/005-vue-ergonomics.md)). Closes #900, #901, #902; advances the [#907](https://github.com/tada5hi/ilingo/issues/907) umbrella.

### #900 — \`<ITranslateT>\` slot-aware component

Messages can carry \`{slot}\` placeholders (single curly) alongside the usual \`{{var}}\` interpolations (double curly). Each \`{slot}\` is filled by a named scoped slot:

\`\`\`vue
<ITranslateT path=\"app.welcome\" :data=\"{ user: 'Peter' }\">
    <template #cta>
        <a href=\"/start\">get started</a>
    </template>
</ITranslateT>
<!-- → <span>Hi Peter, please <a href=\"/start\">get started</a> to continue.</span> -->
\`\`\`

Tag defaults to \`<span>\`; pass \`tag=\"\"\` for a fragment. Unfilled slot placeholders stay as literal text — never throw.

### #901 — \`v-t\` directive

\`\`\`vue
<p v-t=\"'app.greeting'\"></p>
<p v-t=\"{ path: 'app.greet', data: { name: 'Peter' } }\"></p>
<p v-t=\"{ group: 'cart', key: 'items', count: 3 }\"></p>
\`\`\`

Writes the translation to \`textContent\` and reacts to locale changes via \`watchEffect\` — element identity is preserved across locale flips (no remount). Globally registered by \`install()\`; opt out per-app via \`Options.directives: false\`.

### #902 — \`useScopedCatalog\`

Per-component message scope. Creates a fresh \`Ilingo\` with the scoped messages registered first, then re-adds the parent's stores so non-scoped keys still fall through. Descendants see the scope via plain \`useTranslation\`; siblings outside the subtree are unaffected.

\`\`\`vue
<script setup>
const { t } = useScopedCatalog({
    messages: { en: { modal: { greeting: 'Welcome to the modal!' } } },
});
const greeting = t({ group: 'modal', key: 'greeting' });
</script>
\`\`\`

Returns \`{ instance, t }\` for same-component use because Vue's provide/inject can't reach the current setup's own provides — matches vue-i18n's \`useI18n\` pattern.

## Core support

A new \`tokenize(str): TemplateToken[]\` helper in \`packages/ilingo/src/utils/template.ts\` parses messages into \`text / var / slot\` tokens for VNode-producing renderers. Plain \`template()\` still returns a string for the \`Ilingo.format\` path. Future React/Solid/etc. adapters reuse the same tokenizer.

## Tests

15 new Vue tests via **happy-dom** + **@vue/test-utils** (using \`flushPromises\` — \`computedAsync\` needs the microtask queue flushed, not just \`nextTick\`). 8 new ilingo tokenizer tests in core.

Total runtime tests: **109** (83 ilingo + 11 fs + 15 vue), all green. Build + lint clean across 5 workspaces.

## Test plan

- [x] \`npm run build\` — 5 workspaces (incl. docs)
- [x] \`npm run lint\` — clean
- [x] \`npm run test\` — 109 tests
- [x] \`<ITranslateT path=\"app.welcome\"><template #cta><strong>get started</strong></template></ITranslateT>\` renders the strong inline.
- [x] \`v-t\` reactively updates the DOM when the locale Ref flips, without remounting.
- [x] Scoped messages do not leak to a sibling component.
- [x] \`Options.directives: false\` opts out of \`v-t\` registration.

## Scope decisions

- \`useScopedCatalog\` returns \`{ instance, t }\` *and* calls \`provideIlingo(scoped)\`. Vue's provide can't update the current component's own injections, so same-component \`useTranslation\` would still see the parent — the explicit \`t\` shorthand handles that case. Descendants use plain \`useTranslation\`.
- \`<ITranslateT>\` is a render-function component (\`.ts\`), not a \`.vue\` SFC. Interleaving text + VNode children is more direct in a render function.
- Catalog-aware generics in the Vue composables (\`useTranslation<typeof catalog>\`, etc.) are **left for a follow-up**. The right design is either module augmentation (\`declare module '@ilingo/vue' { interface IlingoCatalog { ... } }\`) or per-call generics — both deserve their own pass.

## Docs (per doc-sync convention)

- \`packages/vue/README.md\` — new sections for \`<ITranslateT>\`, \`v-t\`, \`useScopedCatalog\`.
- \`.agents/architecture.md\` — three new design notes; tokenizer added to file-structure.
- \`.agents/structure.md\` — Vue tree expanded with new files, test/ subdir, template.ts annotation.
- \`.agents/testing.md\` — new \`packages/vue/test/\` entry + happy-dom / flushPromises note.
- \`.agents/plans/005-vue-ergonomics.md\` — In review, acceptance checked, scope-out captured.
- \`.agents/plans/README.md\` — phase 5 row flipped.

## Roadmap

After merging:

- [Phase 6 — DX + custom formatters (#903–#906)](.agents/plans/006-dx-and-loader.md) becomes Ready. \`#906\` (custom formatters) is now \"open the FormatterRegistry to user entries\" — a thin extension of phase 3's work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * <ITranslateT>: slot-aware translation component supporting variable interpolation and optional fragment rendering
  * v-t directive: reactive text-content translations that update with locale changes and avoid stale async results
  * useScopedCatalog: per-component scoped catalogs with parent-fallback behavior

* **Documentation**
  * Updated Vue integration and core docs to cover new component, directive, slot placeholders, and tokenizer helper

* **Tests**
  * Added unit tests covering component, directive, scoped catalogs, and tokenizer behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/ilingo/pull/916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->