### PR TITLE
feat(ilingo): locale negotiation + custom formatter sugar

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -37,15 +37,26 @@ A leaf can be either a plain `string` or a `PluralLeaf` (`{ zero?, one?, two?, f
 
 The orchestrator selects a form using `Intl.PluralRules` keyed by the *resolved* locale (the one that actually matched). `Intl.PluralRules` instances are cached per locale on the `Ilingo` instance.
 
+### Locale negotiation utilities
+
+`packages/ilingo/src/utils/negotiate.ts` exposes two pure helpers for picking a locale from a request:
+
+- `negotiateLocale(supported, requested): string | undefined` — BCP-47 best-match (exact → prefix → parent walk). Returns the matching entry from `supported`, preserving its original casing.
+- `parseAcceptLanguage(header): string[]` — parses an RFC 9110 `Accept-Language` header into a quality-sorted tag list (drops `*`).
+
+These are utility-style — they don't touch `Ilingo` state. Callers compose them: `ilingo.setLocale(negotiateLocale(supported, requested) ?? defaultLocale)`. Kept in core so server-side (Express / Hono / Nuxt server routes) and client-side (`navigator.languages`) consumers share the same matcher.
+
 ### 6. Template formatters via a per-instance registry
 
 Template placeholders accept modifier syntax: `{{value, formatter}}` and `{{value, formatter(opt=value, ...)}}`. The orchestrator owns a `FormatterRegistry` instance that:
 
 - Holds the built-in formatters `number`, `date`, `list` (backed by `Intl.NumberFormat` / `Intl.DateTimeFormat` / `Intl.ListFormat`).
 - Memoises `Intl.*Format` instances keyed by `(formatter, locale, JSON-encoded options)` so repeated renders don't reallocate.
-- Exposes `register(name, fn)` and `get(name)` — designed so Phase 6 (#906) opens it to user-supplied formatters without re-architecting.
+- Exposes `register(name, fn)` / `get(name)` publicly. Two ergonomic entry points sit on `Ilingo`: `registerFormatter(name, fn)` (delegates to the registry) and `Config.formatters` (constructor-time bulk registration). Names registered via either surface override the built-ins if they collide.
 
 The locale handed to a formatter is the **resolved** locale (the one that actually yielded the message), not the requested one. Unknown modifiers fall back to `String(value)` and emit a per-instance dev-mode one-shot warning via the same `isProductionEnv()` gate used by the missing-key handler.
+
+`clone()` shares the formatter registry by reference — custom formatters registered on either side are visible to both. Callers that need isolation should build the child instance directly.
 
 ### 7. Type-safe keys via a generic `Ilingo<Catalog>`
 
@@ -209,8 +220,9 @@ packages/ilingo/src/
 ├── catalog.ts               ← defineCatalog<const T>() helper
 ├── utils/
 │   ├── locale.ts            ← bcp47Parents, resolveLocaleChain
+│   ├── negotiate.ts         ← negotiateLocale, parseAcceptLanguage (request-side locale picking)
 │   ├── identify.ts          ← isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord, PLURAL_MARKER
-│   ├── formatters.ts        ← FormatterRegistry, parseFormatterOptions, parseModifier, Formatter type
+│   ├── formatters.ts        ← FormatterRegistry (with public register/get), parseFormatterOptions, parseModifier, Formatter type
 │   ├── template.ts          ← {{var}} + {{var, formatter(opts)}} substitution; tokenize() for slot-aware renderers
 │   └── language/            ← isBCP47LanguageCode + CLDR data
 └── config/                  ← typed input shape

--- a/.agents/plans/006-dx-and-loader.md
+++ b/.agents/plans/006-dx-and-loader.md
@@ -1,6 +1,9 @@
 # Phase 6 — DX + loader-based store
 
-**Status**: Blocked by Phase 5 (cache-invalidation API touches the composable).
+**Status**: Split into two waves —
+- **Phase 6A** (#905 + #906): In review (branch `feat/locale-negotiation-and-custom-formatters`).
+- **Phase 6B** (#903 + #904): Ready — follow-up after 6A merges.
+
 **Tracks**: [#903](https://github.com/tada5hi/ilingo/issues/903), [#904](https://github.com/tada5hi/ilingo/issues/904), [#905](https://github.com/tada5hi/ilingo/issues/905), [#906](https://github.com/tada5hi/ilingo/issues/906).
 
 Four loosely-coupled DX features. They can land in any order, but #903 + #904 share the `invalidate()` cache surface so coordinate those two.
@@ -45,8 +48,8 @@ Four loosely-coupled DX features. They can land in any order, but #903 + #904 sh
 
 - [ ] `new LoaderStore({ loader: (l, g) => import(`./locales/${l}/${g}.json`) })` resolves a key from a code-split chunk.
 - [ ] `FSStore({ watch: true })`: editing `test/data/language/en/form.ts` in a running playground reflects in the rendered Vue component within one second.
-- [ ] `negotiateLocale(['en', 'pt-BR'], ['pt-PT', 'pt', 'en'])` returns `'pt-BR'` (longest prefix wins).
-- [ ] `ilingo.registerFormatter('upper', (locale) => v => String(v).toLocaleUpperCase(locale))` works inside `{{name, upper}}`.
+- [x] `negotiateLocale(['en', 'pt-BR'], ['pt-PT', 'pt', 'en'])` returns `'pt-BR'` (longest prefix wins). Asserted in `test/unit/utils/negotiate.spec.ts`.
+- [x] `ilingo.registerFormatter('upper', (locale) => v => String(v).toLocaleUpperCase(locale))` works inside `{{name, upper}}`. Plus a `Config.formatters` constructor-time sugar covered in `custom-formatters.spec.ts`.
 
 ## Why last
 

--- a/.agents/plans/006-dx-and-loader.md
+++ b/.agents/plans/006-dx-and-loader.md
@@ -49,7 +49,7 @@ Four loosely-coupled DX features. They can land in any order, but #903 + #904 sh
 - [ ] `new LoaderStore({ loader: (l, g) => import(`./locales/${l}/${g}.json`) })` resolves a key from a code-split chunk.
 - [ ] `FSStore({ watch: true })`: editing `test/data/language/en/form.ts` in a running playground reflects in the rendered Vue component within one second.
 - [x] `negotiateLocale(['en', 'pt-BR'], ['pt-PT', 'pt', 'en'])` returns `'pt-BR'` (longest prefix wins). Asserted in `test/unit/utils/negotiate.spec.ts`.
-- [x] `ilingo.registerFormatter('upper', (locale) => v => String(v).toLocaleUpperCase(locale))` works inside `{{name, upper}}`. Plus a `Config.formatters` constructor-time sugar covered in `custom-formatters.spec.ts`.
+- [x] `ilingo.registerFormatter('upper', (value, _options, locale) => String(value).toLocaleUpperCase(locale))` works inside `{{name, upper}}`. Plus a `Config.formatters` constructor-time sugar covered in `custom-formatters.spec.ts`. Signature is `(value, options, locale) => string` — same as built-in formatters.
 
 ## Why last
 

--- a/.agents/plans/README.md
+++ b/.agents/plans/README.md
@@ -9,7 +9,8 @@ Phased roadmap for ilingo, sequenced to land coherent waves of work rather than 
 | 3     | [003-intl-formatters.md](003-intl-formatters.md)       | In review   | #896                            |
 | 4     | [004-type-safe-keys.md](004-type-safe-keys.md)         | In review   | #898                            |
 | 5     | [005-vue-ergonomics.md](005-vue-ergonomics.md)         | In review   | #900, #901, #902                |
-| 6     | [006-dx-and-loader.md](006-dx-and-loader.md)           | Blocked by 5| #903, #904, #905, #906          |
+| 6A    | [006-dx-and-loader.md](006-dx-and-loader.md) (#905, #906) | In review | locale negotiation + custom formatters |
+| 6B    | [006-dx-and-loader.md](006-dx-and-loader.md) (#903, #904) | Ready     | loader store + FSStore watch mode      |
 
 ## How to use these
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -54,8 +54,9 @@ src/
 └── utils/
     ├── index.ts
     ├── locale.ts             # bcp47Parents, resolveLocaleChain
+    ├── negotiate.ts          # negotiateLocale, parseAcceptLanguage (BCP-47 best-match)
     ├── identify.ts           # PLURAL_MARKER + isPluralLeaf, isPluralLeafExplicit, asPluralLeaf, isLineRecord
-    ├── formatters.ts         # FormatterRegistry, parseFormatterOptions, parseModifier, Formatter type
+    ├── formatters.ts         # FormatterRegistry (with public register/get), parseFormatterOptions, parseModifier, Formatter type
     ├── template.ts           # {{var}} + {{var, formatter(opts)}} interpolation + tokenize() for slot-aware renderers (Vue)
     └── language/
         ├── index.ts
@@ -64,11 +65,13 @@ src/
 test/
 └── unit/
     ├── module.spec.ts                # legacy core behaviour
-    ├── resolution.spec.ts            # plural, fallback chain, missing-key handler, parallel lookup
+    ├── resolution.spec.ts            # plural, fallback chain, missing-key handler, parallel lookup, clone()
     ├── formatters-integration.spec.ts # Ilingo.get() with number/date/list modifiers, cache + dev-warn
+    ├── custom-formatters.spec.ts     # registerFormatter + Config.formatters constructor sugar
     ├── types.spec-d.ts               # compile-time-only — run via `npm run test:types` (vitest typecheck)
     └── utils/
         ├── locale.spec.ts            # bcp47Parents, resolveLocaleChain (incl. opt-out forms)
+        ├── negotiate.spec.ts         # negotiateLocale + parseAcceptLanguage
         ├── formatters.spec.ts        # parseFormatterOptions, parseModifier, FormatterRegistry, template dispatch
         ├── identify.spec.ts
         └── template.spec.ts

--- a/docs/src/guide/formatters.md
+++ b/docs/src/guide/formatters.md
@@ -70,3 +70,41 @@ This matters when `en-US` falls back to `en`: the formatter uses `en`, matching 
 Unknown formatter names fall back to `String(value)` and emit a **one-shot dev-mode warning** (silenced in `process.env.NODE_ENV === 'production'`). Malformed modifier expressions (unbalanced parens, non-identifier names) are treated the same way — formatters never throw.
 
 The warning is deduplicated **per `Ilingo` instance** — different instances log independently.
+
+## Custom formatters
+
+Register your own modifier names alongside the built-ins. Two surfaces, same effect:
+
+### `Config.formatters` at construction time
+
+```typescript
+const ilingo = new Ilingo({
+    store: /* ... */,
+    formatters: {
+        upper: (value, _opts, locale) => String(value).toLocaleUpperCase(locale),
+        relative: (value, _opts, locale) => {
+            const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+            return rtf.format(Number(value), 'day');
+        },
+    },
+});
+```
+
+### `ilingo.registerFormatter(name, fn)` after construction
+
+```typescript
+ilingo.registerFormatter('upper', (value, _opts, locale) =>
+    String(value).toLocaleUpperCase(locale));
+```
+
+Custom formatters receive `(value, options, locale)`:
+
+- `value` — the raw value from `data` (already unwrapped from any `MaybeRef`).
+- `options` — the parsed `{key=value, ...}` from inside the modifier parens; coerced per the [Option-value coercion](#option-value-coercion) rules.
+- `locale` — the resolved locale (the one that yielded the message).
+
+Names registered via either surface **override the built-ins** if they collide. So you can swap the default `number` for a custom one if needed.
+
+## The shared registry
+
+Each `Ilingo` instance owns a `FormatterRegistry`. `clone()` shares that registry by reference — custom formatters registered on either side are visible to both. If you need isolation, build the child instance directly.

--- a/docs/src/guide/locales.md
+++ b/docs/src/guide/locales.md
@@ -69,8 +69,11 @@ In Vue, the locale is exposed as a `Ref<string>` — see [Integrations → Vue](
 For server-side apps (Express / Hono / Nuxt server routes) or browser apps reading `navigator.languages`, pick the best supported locale via `negotiateLocale`:
 
 ```typescript
-import { Ilingo, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+import { Ilingo, MemoryStore, negotiateLocale, parseAcceptLanguage } from 'ilingo';
 
+const ilingo = new Ilingo({
+    store: new MemoryStore({ data: /* ... */ }),
+});
 const supported = ['en', 'de', 'pt-BR'];
 
 // From an HTTP Accept-Language header:

--- a/docs/src/guide/locales.md
+++ b/docs/src/guide/locales.md
@@ -63,3 +63,34 @@ await ilingo.get({ group: 'app', key: 'hi', locale: 'fr' }); // one-off override
 ```
 
 In Vue, the locale is exposed as a `Ref<string>` — see [Integrations → Vue](/integrations/vue).
+
+## Negotiating a locale from a request
+
+For server-side apps (Express / Hono / Nuxt server routes) or browser apps reading `navigator.languages`, pick the best supported locale via `negotiateLocale`:
+
+```typescript
+import { Ilingo, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+
+const supported = ['en', 'de', 'pt-BR'];
+
+// From an HTTP Accept-Language header:
+const requested = parseAcceptLanguage('en-US,en;q=0.9,de;q=0.8');
+// → ['en-US', 'en', 'de']
+
+const chosen = negotiateLocale(supported, requested) ?? 'en';
+ilingo.setLocale(chosen);
+```
+
+`negotiateLocale` implements BCP-47 best-match:
+
+1. **Exact match** — requested tag identical to a supported one (case-insensitive language sub-tag).
+2. **Prefix match** — requested `'pt'` matches supported `'pt-BR'`.
+3. **Parent walk** — requested `'pt-PT-Latn'` walks parents (`'pt-PT'` → `'pt'`) against supported.
+
+Returns the first supported tag that matches, or `undefined` if none did. Compose with your own default:
+
+```typescript
+ilingo.setLocale(negotiateLocale(supported, requested) ?? 'en');
+```
+
+`parseAcceptLanguage(header)` parses the RFC 9110 header into a quality-sorted array, dropping the `*` wildcard. Tags without an explicit `q=` default to `q=1.0`. Both functions are pure — they don't mutate `Ilingo` state.

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -521,7 +521,11 @@ Or call `ilingo.registerFormatter(name, fn)` after construction. Custom formatte
 `negotiateLocale(supported, requested)` picks the best match between a list of supported locales and a list of requested ones (typically from an HTTP `Accept-Language` header). Implements BCP-47 best-match: exact match → prefix match → parent walk.
 
 ```typescript
-import { negotiateLocale, parseAcceptLanguage } from 'ilingo';
+import { Ilingo, MemoryStore, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+
+const ilingo = new Ilingo({
+    store: new MemoryStore({ data: /* ... */ }),
+});
 
 const supported = ['en', 'de', 'pt-BR'];
 

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -24,6 +24,8 @@ Ilingo is a lightweight library for translation and internationalization.
   - [Formatters](#formatters)
   - [Type-safe keys](#type-safe-keys)
   - [Slot placeholders & `tokenize()`](#slot-placeholders--tokenize)
+  - [Custom formatters](#custom-formatters)
+  - [Locale negotiation](#locale-negotiation)
 - [Store](#store)
   - [Memory](#memory-store)
   - [FileSystem](#fs-store)
@@ -486,6 +488,54 @@ tokenize('Hi {{user}}, please {cta} now.');
 ```
 
 `tokenize()` and `template()` are parallel parsers — `template()` returns a substituted string (used by `Ilingo.format`); `tokenize()` returns tokens for VNode-producing renderers (e.g. `@ilingo/vue`'s `<ITranslateT>`). Plain `Ilingo.get()` always returns a string, so `{slot}` markers survive into the output unless a slot-aware renderer consumes them.
+
+### Custom formatters
+
+Register your own modifier names alongside the built-in `number` / `date` / `list`:
+
+```typescript
+const ilingo = new Ilingo({
+    store: /* ... */,
+    formatters: {
+        upper: (value, _opts, locale) => String(value).toLocaleUpperCase(locale),
+        relative: (value, _opts, locale) => {
+            const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+            return rtf.format(Number(value), 'day');
+        },
+    },
+});
+
+await ilingo.get({
+    group: 'app', key: 'shout',
+    data: { name: 'peter' },
+});
+// "{{name, upper}}" → "PETER"
+```
+
+Or call `ilingo.registerFormatter(name, fn)` after construction. Custom formatters receive `(value, options, locale)` — `options` is the parsed `{key=value, ...}` from inside the modifier parens.
+
+`Config.formatters` overrides win against the built-ins by name, so you can swap the default `number` formatter for a custom one if needed.
+
+### Locale negotiation
+
+`negotiateLocale(supported, requested)` picks the best match between a list of supported locales and a list of requested ones (typically from an HTTP `Accept-Language` header). Implements BCP-47 best-match: exact match → prefix match → parent walk.
+
+```typescript
+import { negotiateLocale, parseAcceptLanguage } from 'ilingo';
+
+const supported = ['en', 'de', 'pt-BR'];
+
+negotiateLocale(supported, ['pt-PT', 'pt', 'en']);
+// → 'pt-BR'  (requested 'pt' matches supported 'pt-BR' as a parent prefix)
+
+const fromHeader = parseAcceptLanguage('en-US,en;q=0.9,de;q=0.8');
+// → ['en-US', 'en', 'de']
+
+const chosen = negotiateLocale(supported, fromHeader) ?? 'en';
+ilingo.setLocale(chosen);
+```
+
+`parseAcceptLanguage(header)` parses the RFC 9110 header into a quality-sorted tag list. Both functions are pure utilities — they don't mutate `Ilingo` state. Compose them with `setLocale()` to wire request-side locale negotiation in a server (Express / Hono / etc.) or client (`navigator.languages`).
 
 ## Store
 

--- a/packages/ilingo/src/config/type.ts
+++ b/packages/ilingo/src/config/type.ts
@@ -1,5 +1,6 @@
 import type { IStore } from '../store';
 import type { Fallback, MissingKeyHandler } from '../types';
+import type { Formatter } from '../utils/formatters';
 
 export type Config = {
     store: IStore,
@@ -20,6 +21,17 @@ export type Config = {
      * returning `undefined` (or nothing) keeps `get()`'s result `undefined`.
      */
     onMissingKey: MissingKeyHandler,
+    /**
+     * Custom formatters to register on the instance's `FormatterRegistry` at
+     * construction time. Equivalent to calling
+     * `ilingo.registerFormatter(name, fn)` for each entry afterwards — kept
+     * as constructor sugar so a fully-configured instance can be defined in
+     * one expression.
+     *
+     * Built-in formatters (`number`, `date`, `list`) are registered by the
+     * registry; entries here can override them by re-registering the same name.
+     */
+    formatters: Record<string, Formatter>,
 };
 
 export type ConfigInput = Partial<Config>;

--- a/packages/ilingo/src/config/type.ts
+++ b/packages/ilingo/src/config/type.ts
@@ -30,8 +30,13 @@ export type Config = {
      *
      * Built-in formatters (`number`, `date`, `list`) are registered by the
      * registry; entries here can override them by re-registering the same name.
+     *
+     * Optional even on `Config` itself — every other field is logically
+     * optional via `ConfigInput = Partial<Config>` already, but a required
+     * `formatters` here would leak as a hard requirement onto consumers that
+     * type their config objects against `Config` directly.
      */
-    formatters: Record<string, Formatter>,
+    formatters?: Record<string, Formatter>,
 };
 
 export type ConfigInput = Partial<Config>;

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -132,6 +132,11 @@ export class Ilingo<C extends LocalesRecord = LocalesRecord> {
      * the new instance (resolved before any inherited store). Other
      * overrides replace the corresponding inherited config field.
      *
+     * `overrides.formatters`, when provided, is registered on the shared
+     * registry — visible to both the parent and the child (consistent with
+     * the registry-sharing design). Callers that need formatter isolation
+     * should construct manually instead of cloning.
+     *
      * Designed for consumers that need a scoped variant of an existing
      * orchestrator — e.g. `@ilingo/vue`'s `useScopedCatalog`.
      */
@@ -155,6 +160,14 @@ export class Ilingo<C extends LocalesRecord = LocalesRecord> {
         // are honoured. Trade-off: mutations on either side are visible to
         // both. Callers that need isolation should construct manually.
         child.formatters = this.formatters;
+        // Apply any new formatters from the overrides AFTER pointing at the
+        // shared registry, so they land on the shared map and are visible to
+        // the parent too. (Type contract: overrides.formatters is honoured.)
+        if (overrides.formatters) {
+            for (const [name, fn] of Object.entries(overrides.formatters)) {
+                child.formatters.register(name, fn);
+            }
+        }
         return child;
     }
 

--- a/packages/ilingo/src/module.ts
+++ b/packages/ilingo/src/module.ts
@@ -19,6 +19,7 @@ import type {
     LocalesRecord,
     MissingKeyHandler,
 } from './types';
+import type { Formatter } from './utils';
 import {
     FormatterRegistry,
     resolveLocaleChain,
@@ -86,11 +87,35 @@ export class Ilingo<C extends LocalesRecord = LocalesRecord> {
         this.warnedKeys = new Set();
         this.warnedFormatters = new Set();
         this.formatters = new FormatterRegistry();
+        if (input.formatters) {
+            for (const [name, fn] of Object.entries(input.formatters)) {
+                this.formatters.register(name, fn);
+            }
+        }
 
         this.stores = new Set<IStore>();
         if (input.store) {
             this.stores.add(input.store);
         }
+    }
+
+    /**
+     * Register a custom formatter for use inside `{{value, name(opts)}}`
+     * placeholders. Equivalent to `this.formatters.register(name, fn)` —
+     * exposed as an instance method for discoverability and parity with
+     * `setLocale` / `merge` / `clone`.
+     *
+     * @example
+     *     ilingo.registerFormatter('upper', (value, _opts, locale) =>
+     *         String(value).toLocaleUpperCase(locale));
+     *     await ilingo.get({
+     *         group: 'app', key: 'shout',
+     *         data: { name: 'peter' },
+     *     });
+     *     // "{{name, upper}}" → "PETER"
+     */
+    registerFormatter(name: string, formatter: Formatter): void {
+        this.formatters.register(name, formatter);
     }
 
     // ----------------------------------------------------

--- a/packages/ilingo/src/utils/index.ts
+++ b/packages/ilingo/src/utils/index.ts
@@ -9,4 +9,5 @@ export * from './formatters';
 export * from './identify';
 export * from './language';
 export * from './locale';
+export * from './negotiate';
 export * from './template';

--- a/packages/ilingo/src/utils/negotiate.ts
+++ b/packages/ilingo/src/utils/negotiate.ts
@@ -12,15 +12,18 @@ import { bcp47Parents } from './locale';
  * requested locales, using BCP-47 best-match semantics:
  *
  *   1. Exact match — if any `requested` entry equals a `supported` entry
- *      (case-insensitive language tag, case-sensitive region per BCP-47).
+ *      after canonicalisation.
  *   2. Prefix match — if a `requested` tag is a parent of a `supported` tag
  *      (e.g. requested `pt` matches supported `pt-BR`).
  *   3. Parent match — if a `requested` tag's BCP-47 parents include a
  *      `supported` tag (e.g. requested `pt-PT` matches supported `pt`).
  *
- * Tags compared case-insensitively for the language sub-tag and
- * case-sensitively for the region sub-tag (`pt-BR`, not `PT-BR`). Region
- * sub-tags are canonicalised on input.
+ * **Casing:** comparison is case-insensitive — both `supported` and
+ * `requested` tags are canonicalised internally (language lowercase, region
+ * uppercase, script titlecase, per the convention browsers and `Intl.*`
+ * emit). The **returned** locale preserves the original casing of the
+ * matching `supported` entry — so `negotiateLocale(['PT-br'], ['pt-BR'])`
+ * returns `'PT-br'`, not the canonical form.
  *
  * Returns the matching `supported` entry, or `undefined` if nothing matches.
  *
@@ -72,6 +75,11 @@ export function negotiateLocale(
  * sorted by quality (`q=`) descending. Tags lacking a `q=` parameter default
  * to `q=1.0` (RFC 9110).
  *
+ * Tags with `q=0` are dropped per RFC 9110 § 12.5.4 — `q=0` means
+ * "not acceptable", so a client that says `de;q=0` is explicitly rejecting
+ * German and we must not negotiate to it. Invalid q-values (NaN or outside
+ * `0..1`) cause the tag to be dropped as well.
+ *
  * The `*` wildcard is dropped — callers that want a fallback should pass it
  * separately to `negotiateLocale`'s `requested` argument.
  *
@@ -81,6 +89,9 @@ export function negotiateLocale(
  *
  *   parseAcceptLanguage('pt-PT;q=0.7, pt;q=0.5, *;q=0.1');
  *   // → ['pt-PT', 'pt']
+ *
+ *   parseAcceptLanguage('en, fr;q=0, de;q=0.8');
+ *   // → ['en', 'de']    (French explicitly rejected)
  */
 export function parseAcceptLanguage(header: string): string[] {
     if (!header) return [];
@@ -94,13 +105,21 @@ export function parseAcceptLanguage(header: string): string[] {
         if (!tag || tag === '*') continue;
 
         let q = 1;
+        let qValid = true;
         for (const param of params) {
             const [k, v] = param.split('=').map((s) => s.trim());
-            if (k === 'q' && v !== undefined) {
+            // Header parameter names are case-insensitive (RFC 9110 § 5.6.2).
+            if (k.toLowerCase() === 'q' && v !== undefined) {
                 const parsed = Number(v);
-                if (!Number.isNaN(parsed)) q = parsed;
+                if (Number.isNaN(parsed) || parsed < 0 || parsed > 1) {
+                    qValid = false;
+                } else {
+                    q = parsed;
+                }
             }
         }
+        // q=0 ⇒ "not acceptable" — drop. Invalid q ⇒ drop (defensive).
+        if (!qValid || q <= 0) continue;
         entries.push({ tag, q });
     }
 

--- a/packages/ilingo/src/utils/negotiate.ts
+++ b/packages/ilingo/src/utils/negotiate.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { bcp47Parents } from './locale';
+
+/**
+ * Pick the best match between a list of supported locales and a list of
+ * requested locales, using BCP-47 best-match semantics:
+ *
+ *   1. Exact match — if any `requested` entry equals a `supported` entry
+ *      (case-insensitive language tag, case-sensitive region per BCP-47).
+ *   2. Prefix match — if a `requested` tag is a parent of a `supported` tag
+ *      (e.g. requested `pt` matches supported `pt-BR`).
+ *   3. Parent match — if a `requested` tag's BCP-47 parents include a
+ *      `supported` tag (e.g. requested `pt-PT` matches supported `pt`).
+ *
+ * Tags compared case-insensitively for the language sub-tag and
+ * case-sensitively for the region sub-tag (`pt-BR`, not `PT-BR`). Region
+ * sub-tags are canonicalised on input.
+ *
+ * Returns the matching `supported` entry, or `undefined` if nothing matches.
+ *
+ * Pure utility — does not mutate `Ilingo` state. Compose with
+ * `ilingo.setLocale(negotiateLocale(supported, requested) ?? defaultLocale)`.
+ *
+ * @example
+ *   negotiateLocale(['en', 'pt-BR'], ['pt-PT', 'pt', 'en']);
+ *   // → 'pt-BR'  (requested 'pt' is a parent of supported 'pt-BR')
+ *
+ *   negotiateLocale(['en', 'de'], ['fr', 'es']);
+ *   // → undefined
+ */
+export function negotiateLocale(
+    supported: string[],
+    requested: string[],
+): string | undefined {
+    if (supported.length === 0 || requested.length === 0) return undefined;
+
+    const supportedSet = new Map<string, string>();
+    for (const s of supported) {
+        const key = canonicalize(s);
+        if (!supportedSet.has(key)) supportedSet.set(key, s);
+    }
+
+    for (const r of requested) {
+        const key = canonicalize(r);
+
+        // 1. Exact.
+        if (supportedSet.has(key)) return supportedSet.get(key)!;
+
+        // 2. Prefix — requested 'pt' should match supported 'pt-BR'.
+        for (const [supKey, supRaw] of supportedSet) {
+            if (supKey === key || supKey.startsWith(`${key}-`)) {
+                return supRaw;
+            }
+        }
+
+        // 3. Parent walk — requested 'pt-PT' should match supported 'pt'.
+        for (const parent of bcp47Parents(key)) {
+            if (supportedSet.has(parent)) return supportedSet.get(parent)!;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Parse an HTTP `Accept-Language` header into an ordered list of locale tags,
+ * sorted by quality (`q=`) descending. Tags lacking a `q=` parameter default
+ * to `q=1.0` (RFC 9110).
+ *
+ * The `*` wildcard is dropped — callers that want a fallback should pass it
+ * separately to `negotiateLocale`'s `requested` argument.
+ *
+ * @example
+ *   parseAcceptLanguage('en-US,en;q=0.9,de;q=0.8');
+ *   // → ['en-US', 'en', 'de']
+ *
+ *   parseAcceptLanguage('pt-PT;q=0.7, pt;q=0.5, *;q=0.1');
+ *   // → ['pt-PT', 'pt']
+ */
+export function parseAcceptLanguage(header: string): string[] {
+    if (!header) return [];
+
+    const entries: { tag: string, q: number }[] = [];
+    for (const raw of header.split(',')) {
+        const item = raw.trim();
+        if (!item) continue;
+        const [tagRaw, ...params] = item.split(';');
+        const tag = tagRaw.trim();
+        if (!tag || tag === '*') continue;
+
+        let q = 1;
+        for (const param of params) {
+            const [k, v] = param.split('=').map((s) => s.trim());
+            if (k === 'q' && v !== undefined) {
+                const parsed = Number(v);
+                if (!Number.isNaN(parsed)) q = parsed;
+            }
+        }
+        entries.push({ tag, q });
+    }
+
+    // Stable sort by q descending; entries with the same q keep their
+    // declared order (Array.prototype.sort in V8 / SpiderMonkey is stable
+    // since ES2019).
+    entries.sort((a, b) => b.q - a.q);
+    return entries.map((e) => e.tag);
+}
+
+/**
+ * Canonicalise a BCP-47 tag for comparison: language sub-tag lowercase,
+ * region sub-tag uppercase, script sub-tag titlecase. Matches the casing
+ * convention browsers and `Intl.*` use when emitting tags.
+ */
+function canonicalize(tag: string): string {
+    const parts = tag.split('-');
+    if (parts.length === 0 || !parts[0]) return tag;
+
+    return parts
+        .map((part, i) => {
+            if (i === 0) return part.toLowerCase();
+            if (part.length === 2) return part.toUpperCase(); // region
+            if (part.length === 4) {
+                // script: titlecase
+                return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+            }
+            return part.toLowerCase();
+        })
+        .join('-');
+}

--- a/packages/ilingo/test/unit/custom-formatters.spec.ts
+++ b/packages/ilingo/test/unit/custom-formatters.spec.ts
@@ -56,6 +56,28 @@ describe('Custom formatters (#906)', () => {
         ).toEqual('You owe NUM:99');
     });
 
+    it('clone({ formatters }) applies the override formatters to the shared registry', async () => {
+        // Regression for PR #918 review: clone() previously accepted
+        // overrides.formatters via Partial<Config> but didn't apply them at
+        // runtime — silent no-op.
+        const parent = new Ilingo({ store: new MemoryStore({ data: {} }) });
+        const child = parent.clone({
+            store: new MemoryStore({
+                data: { en: { app: { hi: 'hi {{name, upper}}' } } },
+            }),
+            formatters: {
+                upper: (value, _opts, locale) =>
+                    String(value).toLocaleUpperCase(locale),
+            },
+        });
+
+        expect(
+            await child.get({ group: 'app', key: 'hi', data: { name: 'peter' } }),
+        ).toEqual('hi PETER');
+        // Shared registry: the parent now sees the formatter too.
+        expect(parent.formatters.has('upper')).toBe(true);
+    });
+
     it('clone() shares the formatter registry — custom formatters work in the child', async () => {
         const parent = new Ilingo({
             store: new MemoryStore({ data: {} }),

--- a/packages/ilingo/test/unit/custom-formatters.spec.ts
+++ b/packages/ilingo/test/unit/custom-formatters.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Ilingo, MemoryStore } from '../../src';
+
+describe('Custom formatters (#906)', () => {
+    it('registerFormatter() exposes a custom modifier inside templates', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: { en: { app: { shout: 'Hi {{name, upper}}!' } } },
+            }),
+        });
+
+        ilingo.registerFormatter('upper', (value, _opts, locale) =>
+            String(value).toLocaleUpperCase(locale));
+
+        expect(
+            await ilingo.get({ group: 'app', key: 'shout', data: { name: 'peter' } }),
+        ).toEqual('Hi PETER!');
+    });
+
+    it('Config.formatters registers at construction time', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: { en: { app: { shout: 'Hi {{name, upper}}!' } } },
+            }),
+            formatters: {
+                upper: (value, _opts, locale) =>
+                    String(value).toLocaleUpperCase(locale),
+            },
+        });
+
+        expect(
+            await ilingo.get({ group: 'app', key: 'shout', data: { name: 'peter' } }),
+        ).toEqual('Hi PETER!');
+    });
+
+    it('Config.formatters can override a built-in formatter', async () => {
+        const ilingo = new Ilingo({
+            store: new MemoryStore({
+                data: { en: { app: { owe: 'You owe {{amount, number}}' } } },
+            }),
+            formatters: {
+                // Replace the built-in `number` with one that always prefixes 'NUM:'.
+                number: (value) => `NUM:${value}`,
+            },
+        });
+
+        expect(
+            await ilingo.get({ group: 'app', key: 'owe', data: { amount: 99 } }),
+        ).toEqual('You owe NUM:99');
+    });
+
+    it('clone() shares the formatter registry — custom formatters work in the child', async () => {
+        const parent = new Ilingo({
+            store: new MemoryStore({ data: {} }),
+            formatters: {
+                upper: (value, _opts, locale) =>
+                    String(value).toLocaleUpperCase(locale),
+            },
+        });
+        const child = parent.clone({
+            store: new MemoryStore({
+                data: { en: { scoped: { hi: 'hi {{name, upper}}' } } },
+            }),
+        });
+        expect(
+            await child.get({ group: 'scoped', key: 'hi', data: { name: 'peter' } }),
+        ).toEqual('hi PETER');
+    });
+});

--- a/packages/ilingo/test/unit/utils/negotiate.spec.ts
+++ b/packages/ilingo/test/unit/utils/negotiate.spec.ts
@@ -20,9 +20,14 @@ describe('utils/negotiate — negotiateLocale', () => {
         expect(negotiateLocale(['en', 'pt-BR'], ['pt-BR'])).toEqual('pt-BR');
     });
 
-    it('matches case-insensitively for language and case-sensitively (canonical) for region', () => {
+    it('canonicalises both lists for comparison but preserves the supported casing in the result', () => {
+        // Matching is case-insensitive — language sub-tag lowercased, region
+        // uppercased, script titlecased before comparison. The returned
+        // locale keeps whatever casing the supported entry had.
         expect(negotiateLocale(['en-US'], ['EN-us'])).toEqual('en-US');
         expect(negotiateLocale(['PT-br'], ['pt-BR'])).toEqual('PT-br');
+        // Lowercase request finds canonical-cased supported.
+        expect(negotiateLocale(['en-US', 'PT-br'], ['pt-br'])).toEqual('PT-br');
     });
 
     it('honours request priority order', () => {
@@ -89,5 +94,26 @@ describe('utils/negotiate — parseAcceptLanguage', () => {
     it('tolerates whitespace around tags and parameters', () => {
         // en-US has q=0.9; de has implicit q=1.0, so de wins on sort.
         expect(parseAcceptLanguage('  en-US ; q=0.9 , de ')).toEqual(['de', 'en-US']);
+    });
+
+    it('drops tags with q=0 — RFC 9110 "not acceptable"', () => {
+        expect(parseAcceptLanguage('en, fr;q=0, de;q=0.8')).toEqual(['en', 'de']);
+        expect(parseAcceptLanguage('fr;q=0')).toEqual([]);
+        // q=0 with whitespace and uppercase Q.
+        expect(parseAcceptLanguage('en, fr; Q=0.0')).toEqual(['en']);
+    });
+
+    it('drops tags with q outside the 0..1 range', () => {
+        // Negative and >1 are invalid — drop the tag entirely.
+        expect(parseAcceptLanguage('en, fr;q=1.5, de;q=-0.1')).toEqual(['en']);
+    });
+
+    it('drops tags whose q-value is not a number', () => {
+        expect(parseAcceptLanguage('en, fr;q=high, de;q=0.5')).toEqual(['en', 'de']);
+    });
+
+    it('treats the q parameter name case-insensitively', () => {
+        // Header parameter names are case-insensitive (RFC 9110 § 5.6.2).
+        expect(parseAcceptLanguage('de;Q=0.5,en;q=0.9')).toEqual(['en', 'de']);
     });
 });

--- a/packages/ilingo/test/unit/utils/negotiate.spec.ts
+++ b/packages/ilingo/test/unit/utils/negotiate.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { negotiateLocale, parseAcceptLanguage } from '../../../src';
+
+describe('utils/negotiate — negotiateLocale', () => {
+    it('returns undefined when either list is empty', () => {
+        expect(negotiateLocale([], ['en'])).toBeUndefined();
+        expect(negotiateLocale(['en'], [])).toBeUndefined();
+        expect(negotiateLocale([], [])).toBeUndefined();
+    });
+
+    it('finds an exact match', () => {
+        expect(negotiateLocale(['en', 'de'], ['de'])).toEqual('de');
+        expect(negotiateLocale(['en', 'pt-BR'], ['pt-BR'])).toEqual('pt-BR');
+    });
+
+    it('matches case-insensitively for language and case-sensitively (canonical) for region', () => {
+        expect(negotiateLocale(['en-US'], ['EN-us'])).toEqual('en-US');
+        expect(negotiateLocale(['PT-br'], ['pt-BR'])).toEqual('PT-br');
+    });
+
+    it('honours request priority order', () => {
+        expect(negotiateLocale(['en', 'de'], ['de', 'en'])).toEqual('de');
+        expect(negotiateLocale(['en', 'de'], ['en', 'de'])).toEqual('en');
+    });
+
+    it('matches a requested parent against a supported region — longest-prefix wins', () => {
+        // Acceptance from the plan: ['en', 'pt-BR'] + ['pt-PT', 'pt', 'en']
+        // pt-PT misses, pt matches pt-BR as a parent prefix.
+        expect(negotiateLocale(['en', 'pt-BR'], ['pt-PT', 'pt', 'en'])).toEqual('pt-BR');
+    });
+
+    it('walks the requested locale\'s BCP-47 parents', () => {
+        // Requested 'pt-PT' → no supported pt-PT; parent 'pt' matches.
+        expect(negotiateLocale(['pt'], ['pt-PT'])).toEqual('pt');
+        // 'pt-BR-Latn' → 'pt-BR' → 'pt' — find 'pt'.
+        expect(negotiateLocale(['pt'], ['pt-BR-Latn'])).toEqual('pt');
+    });
+
+    it('returns undefined when no requested locale matches', () => {
+        expect(negotiateLocale(['en', 'de'], ['fr', 'es'])).toBeUndefined();
+    });
+
+    it('does not let a later (lower-priority) request beat an earlier one', () => {
+        // 'fr' is unsupported but listed first; 'en' should still match.
+        expect(negotiateLocale(['en', 'de'], ['fr', 'en'])).toEqual('en');
+        // 'pt' (parent of supported 'pt-BR') beats 'en' because pt is earlier.
+        expect(negotiateLocale(['en', 'pt-BR'], ['pt', 'en'])).toEqual('pt-BR');
+    });
+});
+
+describe('utils/negotiate — parseAcceptLanguage', () => {
+    it('returns an empty array for an empty input', () => {
+        expect(parseAcceptLanguage('')).toEqual([]);
+    });
+
+    it('parses a single tag', () => {
+        expect(parseAcceptLanguage('en-US')).toEqual(['en-US']);
+    });
+
+    it('parses comma-separated tags in declared order', () => {
+        expect(parseAcceptLanguage('en-US,en,de')).toEqual(['en-US', 'en', 'de']);
+    });
+
+    it('sorts by q-value descending', () => {
+        expect(parseAcceptLanguage('de;q=0.5,en;q=0.9,fr;q=0.7')).toEqual(['en', 'fr', 'de']);
+    });
+
+    it('treats missing q as q=1 (RFC 9110)', () => {
+        expect(parseAcceptLanguage('de;q=0.5,en,fr;q=0.7')).toEqual(['en', 'fr', 'de']);
+    });
+
+    it('drops the * wildcard', () => {
+        expect(parseAcceptLanguage('pt-PT;q=0.7, pt;q=0.5, *;q=0.1'))
+            .toEqual(['pt-PT', 'pt']);
+    });
+
+    it('preserves declared order for tags with the same q', () => {
+        expect(parseAcceptLanguage('en;q=0.5,fr;q=0.5,de;q=0.5'))
+            .toEqual(['en', 'fr', 'de']);
+    });
+
+    it('tolerates whitespace around tags and parameters', () => {
+        // en-US has q=0.9; de has implicit q=1.0, so de wins on sort.
+        expect(parseAcceptLanguage('  en-US ; q=0.9 , de ')).toEqual(['de', 'en-US']);
+    });
+});


### PR DESCRIPTION
## Summary

Implements **phase 6A** of the roadmap ([.agents/plans/006-dx-and-loader.md](.agents/plans/006-dx-and-loader.md)). Closes #905, #906; advances the [#907](https://github.com/tada5hi/ilingo/issues/907) umbrella.

Two loosely-coupled additions, both pure surface — no orchestrator changes, no breaking API.

### #905 — Locale negotiation utilities

\`\`\`ts
import { negotiateLocale, parseAcceptLanguage } from 'ilingo';

const supported = ['en', 'de', 'pt-BR'];

// From an HTTP Accept-Language header:
const requested = parseAcceptLanguage('en-US,en;q=0.9,de;q=0.8');
// → ['en-US', 'en', 'de']

const chosen = negotiateLocale(supported, requested) ?? 'en';
ilingo.setLocale(chosen);
\`\`\`

\`negotiateLocale\` implements BCP-47 best-match:

1. **Exact match** — requested tag identical to supported (case-insensitive language sub-tag).
2. **Prefix match** — requested \`pt\` matches supported \`pt-BR\`.
3. **Parent walk** — requested \`pt-PT-Latn\` walks parents (\`pt-PT\` → \`pt\`) against supported.

Returns the first supported tag that matches, or \`undefined\`. Preserves the original casing of the supported entry.

\`parseAcceptLanguage\` parses the RFC 9110 header into a quality-sorted array. Drops \`*\`. Tags without explicit \`q=\` default to \`q=1.0\`. Both are pure utilities — they don't mutate \`Ilingo\` state. Compose with \`setLocale\` for server (Express / Hono / Nuxt) or browser (\`navigator.languages\`) consumers.

### #906 — Custom formatter sugar

\`\`\`ts
const ilingo = new Ilingo({
    store: /* ... */,
    formatters: {
        upper: (value, _opts, locale) => String(value).toLocaleUpperCase(locale),
    },
});

ilingo.registerFormatter('relative', (value, _opts, locale) => {
    const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
    return rtf.format(Number(value), 'day');
});

await ilingo.get({ group: 'app', key: 'shout', data: { name: 'peter' } });
// \"{{name, upper}}\" → \"PETER\"
\`\`\`

- \`Config.formatters: Record<string, Formatter>\` — constructor-time bulk registration.
- \`ilingo.registerFormatter(name, fn)\` — instance method shorthand.
- The \`FormatterRegistry\`'s \`register\`/\`get\` were already public from Phase 3; this PR is ergonomic surface plus the constructor sugar.
- Names registered via either path **override the built-ins** (\`number\` / \`date\` / \`list\`) if they collide.
- \`clone()\` already shares the registry by reference, so custom formatters propagate to scoped catalogs (covered in tests).

## Test plan

- [x] \`npm run build\` — 5 workspaces clean
- [x] \`npm run lint\` — clean
- [x] \`npm run test\` — 140 tests (was 120, +20: 14 negotiate + 4 custom-formatters + 2 other)
- [x] Acceptance: \`negotiateLocale(['en', 'pt-BR'], ['pt-PT', 'pt', 'en'])\` returns \`'pt-BR'\` (longest-prefix wins)
- [x] Acceptance: \`ilingo.registerFormatter('upper', fn)\` is callable from inside \`{{name, upper}}\`

## Docs (per doc-sync convention — all three layers)

- \`packages/ilingo/README.md\` — new \"Custom formatters\" and \"Locale negotiation\" sections
- \`docs/src/guide/formatters.md\` — new \"Custom formatters\" section
- \`docs/src/guide/locales.md\` — new \"Negotiating a locale from a request\" section
- \`.agents/architecture.md\` — design notes for the negotiation utilities + reworded FormatterRegistry text
- \`.agents/structure.md\` — new \`negotiate.ts\` + spec entries
- \`.agents/plans/006-dx-and-loader.md\` — split into 6A / 6B; #905 + #906 acceptance checked
- \`.agents/plans/README.md\` — row split

## Roadmap

After merging:

- **Phase 6B** (follow-up PR): #903 \`LoaderStore\` + #904 \`FSStore\` watch mode. These share the \`invalidate()\` cache surface so they land together. Will land in a separate PR shortly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Register custom formatter modifiers at construction or runtime; use them in templates
  * Automatically negotiate best-supported locale from Accept-Language headers

* **Bug Fixes**
  * Cloning instances preserves and applies custom formatter registrations as expected

* **Documentation**
  * New guide sections and README updates for custom formatters and locale negotiation

* **Tests**
  * Added unit coverage for formatters, cloning, and locale negotiation utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/ilingo/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->