### PR TITLE
docs: catalog-design + migration-from-5.0 + anchor audit (Track C)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -106,6 +106,8 @@ Helpers in `packages/ilingo/src/types.ts`:
 
 `defineCatalog<const T>(c)` (`packages/ilingo/src/catalog.ts`) is a runtime identity function with a `const` generic that captures the catalog literal without losing inference — saves callers from sprinkling `as const`.
 
+`defineLocale<const T extends GroupsRecord>(locale)` is the per-locale counterpart, used when each locale lives in its own file (`locales/en.ts`). It preserves literal types through an `export default` and validates the shape against `GroupsRecord` so a stray top-level string is caught at compile time (where `as const` would let it through). Combines with `defineCatalog` — the per-locale const generics flow through `defineCatalog`'s own const generic, so the merged `Ilingo<typeof catalog>` still infers full key paths.
+
 `definePlural<const T>(plural)` is the TS/JS-friendly companion to the explicit `@plural` JSON marker. Returns `{ '@plural': leaf }` — same runtime shape as the JSON literal — with CLDR-category autocomplete and a compile error on missing-`other` / non-CLDR keys. Both forms produce identical runtime data: JSON files keep using the `"@plural"` literal (they can't call functions), TS/JS files use `definePlural()`.
 
 ### 8. ESM-first, dependency-light, browser-safe
@@ -251,7 +253,7 @@ Output:
 packages/ilingo/src/
 ├── module.ts                ← orchestrator (Ilingo class)
 ├── store/{types,memory}     ← port + default adapter
-├── catalog.ts               ← defineCatalog<const T>() helper
+├── catalog.ts               ← defineCatalog<const T>() + defineLocale<const T>() + definePlural<const T>() helpers
 ├── utils/
 │   ├── locale.ts            ← bcp47Parents, resolveLocaleChain
 │   ├── negotiate.ts         ← negotiateLocale, parseAcceptLanguage (request-side locale picking)

--- a/.agents/plans/007-stability-roadmap.md
+++ b/.agents/plans/007-stability-roadmap.md
@@ -24,10 +24,10 @@ Each decision lands as a commit (often docs-only) that nails the contract. Items
 
 ## Track C — Docs completeness + migration
 
-- [ ] **`catalog-design` guide page** covering `defineCatalog` / `definePlural` workflow + JSON-vs-TS authoring trade-offs.
-- [ ] **"Upgrading to stable" guide** enumerating breakages from `ilingo@5.x` / `@ilingo/vue@5.x` to the stable cut, with before/after snippets where the change is mechanical.
+- [x] **`catalog-design` guide page** covering `defineCatalog` / `definePlural` workflow + JSON-vs-TS authoring trade-offs. Lives at `docs/src/guide/catalog-design.md`; wired into the "Concepts" sidebar between Overview and Stores. Cross-linked from the overview page.
+- [x] **Migration guide** enumerating breaking changes since `5.0.0`. Originally framed as "Upgrading to Stable" but trimmed to "From 5.0" — a focused list of breakages a consumer would hit upgrading from the published 5.0.0 to whatever the next release cuts. Purely-additive features are not duplicated here; they live in the matching guide pages. Lives at `docs/src/migration/from-5.0.md` under a new top-level Migration nav entry.
 - [ ] **SSR integration recipe** — at least one. Nuxt is the obvious target since `vue-i18n`'s strongest consumer story is there. Astro is a strong second.
-- [ ] **Doc-anchor audit** — every public export listed in package READMEs has a matching anchor on the docs site.
+- [x] **Doc-anchor audit** — every public symbol mentioned in a package README has at least one anchor on the docs site. Gaps that surfaced and were patched: `MissingKeyHandler` (now referenced in `missing-key.md` alongside the existing `MissingKeyContext` table), `bcp47Parents` + `resolveLocaleChain` (now under a "Low-level helpers" section in `locales.md`).
 
 ## Track D — Test + benchmark floor
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -42,7 +42,7 @@ src/
 ├── types.ts                  # LinesRecord, Leaf, PluralForms, PluralLeaf, GetContext (with count),
 │                             #   MissingKeyContext, MissingKeyHandler, Fallback, FallbackResolver, Data,
 │                             #   AnyGroups, Groups, Key, LeafAt, DottedPaths, IsPluralKey, GetParams
-├── catalog.ts                # defineCatalog<const T>() + definePlural<const T>() typed helpers
+├── catalog.ts                # defineCatalog<const T>() + defineLocale<const T>() + definePlural<const T>() typed helpers
 ├── constants.ts              # LOCALE_DEFAULT = 'en'
 ├── config/
 │   ├── index.ts

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
             { text: 'Getting Started', link: '/getting-started/', activeMatch: '/getting-started/' },
             { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
             { text: 'Integrations', link: '/integrations/', activeMatch: '/integrations/' },
+            { text: 'Migration', link: '/migration/from-5.0', activeMatch: '/migration/' },
         ],
         sidebar: {
             '/getting-started/': [{
@@ -47,6 +48,7 @@ export default defineConfig({
                     text: 'Concepts',
                     items: [
                         { text: 'Overview', link: '/guide/' },
+                        { text: 'Catalog Design', link: '/guide/catalog-design' },
                         { text: 'Stores', link: '/guide/stores' },
                         { text: 'Locales & Fallback', link: '/guide/locales' },
                         { text: 'Templates & Data', link: '/guide/templates' },
@@ -69,6 +71,12 @@ export default defineConfig({
                     { text: 'File System', link: '/integrations/fs' },
                     { text: 'Vue', link: '/integrations/vue' },
                     { text: 'Vuelidate', link: '/integrations/vuelidate' },
+                ],
+            }],
+            '/migration/': [{
+                text: 'Migration',
+                items: [
+                    { text: 'From 5.0', link: '/migration/from-5.0' },
                 ],
             }],
         },

--- a/docs/src/guide/catalog-design.md
+++ b/docs/src/guide/catalog-design.md
@@ -1,0 +1,174 @@
+# Catalog Design
+
+A **catalog** is the nested object you hand to `MemoryStore({ data })` (or persist to disk via `FSStore`). Its shape is small but every layer carries meaning — getting the shape right unlocks BCP-47 fallback, plural selection, and compile-time key inference.
+
+```typescript
+const catalog = {
+    en: {                       // locale
+        app: {                  // group (logical namespace)
+            greeting: 'Hi {{name}}',
+            farewell: 'Bye',
+            cart: {
+                items: {
+                    '@plural': {
+                        one:   '{{count}} item',
+                        other: '{{count}} items',
+                    },
+                },
+            },
+        },
+    },
+    de: {
+        app: { /* same shape */ },
+    },
+};
+```
+
+The shape is `Record<locale, Record<group, nested-record-of-leaves>>`. Each leaf is either a `string` or a `{ "@plural": { ... } }` wrapper. Everything in between is just nested keys you can address with dotted paths.
+
+## Layout choices
+
+The library is agnostic to how you split data across files — it only sees the merged shape once it reaches a store. Two common authoring patterns:
+
+### One file per locale
+
+Every locale lives in a single file (`en.ts`, `de.ts`, `en.json`, …). All groups for that locale are children of the same root.
+
+```typescript
+// locales/en.ts
+export default {
+    app:  { greeting: 'Hi {{name}}' },
+    cart: { items: { '@plural': { one: '...', other: '...' } } },
+};
+```
+
+**Use it when:** locales are small (low hundreds of keys), translators work one locale at a time, you want git diffs to read top-to-bottom per language.
+
+### One file per `(locale, group)`
+
+The pattern `FSStore` walks: `<directory>/<locale>/<group>.json`. Each file holds a single group for a single locale.
+
+```
+locales/
+    en/
+        app.json
+        cart.json
+    de/
+        app.json
+        cart.json
+```
+
+**Use it when:** the catalog is large, multiple translators work in parallel, or you want lazy loading where each group's file is fetched only when its first key is read (`FSStore` and `LoaderStore` both support this).
+
+## `defineCatalog` — keep literal types narrow
+
+The catalog literal carries information the type system can use to infer legal `(group, key)` pairs and detect plural leaves. TypeScript will widen literal types (`'Hi'` → `string`) the moment the value lands in a typed variable, so reach for `defineCatalog` instead of `as const` sprinkling.
+
+```typescript
+import { Ilingo, MemoryStore, defineCatalog } from 'ilingo';
+
+const catalog = defineCatalog({
+    en: { app: { greeting: 'Hi' } },
+});
+
+const ilingo = new Ilingo<typeof catalog>({
+    store: new MemoryStore({ data: catalog }),
+});
+
+ilingo.get({ group: 'app', key: 'greeting' }); // OK
+ilingo.get({ group: 'app', key: 'unknown' });  // type error
+```
+
+`defineCatalog<const T>(catalog)` is a runtime identity function. The work it does is purely at compile time — its `const` generic preserves the per-key literal types so the inferred `Key<C, G>` is the natural set of leaf paths, not `string`.
+
+See [Type-Safe Keys](./type-safe-keys) for the inference rules and the `Ilingo<C>` API.
+
+## Authoring plurals: JSON vs TS/JS
+
+A plural leaf is the `{ "@plural": { ... } }` wrapper. JSON catalogs spell the wrapper as a string-keyed literal; TS/JS catalogs reach for the `definePlural` helper for autocomplete + a compile error on a missing `other`.
+
+### JSON files
+
+```json
+{
+    "cart": {
+        "items": {
+            "@plural": {
+                "one":   "{{count}} item",
+                "other": "{{count}} items"
+            }
+        }
+    }
+}
+```
+
+JSON can't call functions, so the literal `@plural` key is the only option. The `other` form is mandatory at runtime; missing it is detected on lookup, not at load time.
+
+### TS / JS files
+
+```typescript
+import { defineCatalog, definePlural } from 'ilingo';
+
+const catalog = defineCatalog({
+    en: {
+        cart: {
+            items: definePlural({
+                one:   '{{count}} item',
+                other: '{{count}} items',
+            }),
+        },
+    },
+});
+```
+
+`definePlural` returns `{ '@plural': forms }` — identical runtime shape to the JSON literal. The signature `<const T extends PluralForms>(forms: T)` gives you:
+
+- Autocomplete for CLDR categories (`zero | one | two | few | many | other`)
+- A compile error if you omit `other`
+- A compile error if you spell a non-CLDR category (e.g. `singular`)
+- Literal types preserved for downstream `Ilingo<typeof catalog>` inference
+
+When you mix JSON for one locale and TS for another in the same catalog, both wrap to the same runtime shape — `Intl.PluralRules` doesn't care which authoring path produced the leaf.
+
+For the runtime contract and CLDR-category fallback rules, see [Pluralization](./pluralization).
+
+## Bare `{ one, other }` is not a plural
+
+A `{ one: ..., other: ... }` object without the `@plural` wrapper is a regular nested namespace. The store walks past it, the keys `one` and `other` are reachable via dotted access:
+
+```typescript
+const catalog = defineCatalog({
+    en: {
+        form: {
+            kind: {
+                // Just a namespace — sibling keys named after CLDR categories
+                // are safe and addressable individually.
+                other: { label: 'Other' },
+                custom: { label: 'Custom' },
+            },
+        },
+    },
+});
+
+await ilingo.get({ group: 'form', key: 'kind.other.label' });   // "Other"
+await ilingo.get({ group: 'form', key: 'kind' });               // undefined (not a leaf)
+```
+
+This is the inverse design from libraries that auto-detect bare `{ one, other }` shapes — the explicit `@plural` discriminator means a UI catalog with an enum dropdown labelled "Other" never collides with the plural selector.
+
+## Catalog shape recap
+
+| At this position | The value can be |
+|---|---|
+| Top-level | A locale code (`'en'`, `'de'`, `'pt-BR'`, …) — BCP-47 |
+| Locale | A `Record<group, ...>` where each group is your logical namespace |
+| Group | A nested `Record<string, …>` — any depth |
+| Leaf | `string` (the translation) OR `{ "@plural": { other: string, zero?: string, ... } }` |
+
+Keys may be reached as dotted paths (`'cart.items'`, `'nested.deep.leaf'`). The `'@plural'` marker is the only special key name — every other key is treated as a regular namespace step.
+
+## See also
+
+- [Stores](./stores) — how `MemoryStore`, `FSStore`, and `LoaderStore` consume a catalog.
+- [Type-Safe Keys](./type-safe-keys) — the `Ilingo<C>` API and `Key<C, G>` inference.
+- [Pluralization](./pluralization) — selection rules and the runtime contract.

--- a/docs/src/guide/catalog-design.md
+++ b/docs/src/guide/catalog-design.md
@@ -32,15 +32,28 @@ The library is agnostic to how you split data across files — it only sees the 
 
 ### One file per locale
 
-Every locale lives in a single file (`en.ts`, `de.ts`, `en.json`, …). All groups for that locale are children of the same root.
+Every locale lives in a single file (`en.ts`, `de.ts`, `en.json`, …). All groups for that locale are children of the same root. For TS files, wrap the export in `defineLocale` so the per-key literal types survive the `export default` (otherwise TypeScript widens them — see [`defineLocale`](#definelocale-one-file-per-locale-authoring) below).
 
 ```typescript
 // locales/en.ts
-export default {
+import { defineLocale, definePlural } from 'ilingo';
+
+export default defineLocale({
     app:  { greeting: 'Hi {{name}}' },
-    cart: { items: { '@plural': { one: '...', other: '...' } } },
-};
+    cart: { items: definePlural({ one: '1 item', other: '{{count}} items' }) },
+});
 ```
+
+```typescript
+// locales/index.ts — combine into a single catalog
+import { defineCatalog } from 'ilingo';
+import en from './en';
+import de from './de';
+
+export const catalog = defineCatalog({ en, de });
+```
+
+JSON variant is the same shape minus the helper calls — see the `@plural` example under [Authoring plurals](#authoring-plurals-json-vs-tsjs).
 
 **Use it when:** locales are small (low hundreds of keys), translators work one locale at a time, you want git diffs to read top-to-bottom per language.
 
@@ -82,6 +95,43 @@ ilingo.get({ group: 'app', key: 'unknown' });  // type error
 `defineCatalog<const T>(catalog)` is a runtime identity function. The work it does is purely at compile time — its `const` generic preserves the per-key literal types so the inferred `Key<C, G>` is the natural set of leaf paths, not `string`.
 
 See [Type-Safe Keys](./type-safe-keys) for the inference rules and the `Ilingo<C>` API.
+
+## `defineLocale` — one-file-per-locale authoring
+
+When you split locales across files (`locales/en.ts`, `locales/de.ts`, …), each file declares the groups for a single locale. TypeScript widens the literal types at the `export default` boundary unless you tell it not to. `defineLocale` is the per-locale counterpart of `defineCatalog`: an identity function with a `const` generic that captures the narrow shape and validates against `GroupsRecord`.
+
+```typescript
+// locales/en.ts
+import { defineLocale, definePlural } from 'ilingo';
+
+export default defineLocale({
+    app:  { greeting: 'Hi {{name}}' },
+    cart: { items: definePlural({ one: '1 item', other: '{{count}} items' }) },
+});
+```
+
+`as const` would also preserve the types but does no shape validation — a stray top-level string would slip through silently and only fail at lookup. `defineLocale<const T extends GroupsRecord>(locale: T): T` catches that at the call site:
+
+```typescript
+defineLocale({
+    app: 'oops',
+    //   ^^^^^^ type error: not a GroupsRecord entry
+});
+```
+
+When you import the per-locale files into a combined catalog, the const generic flows through `defineCatalog`, so `Ilingo<typeof catalog>` still infers the full set of legal `(group, key)` pairs across every locale:
+
+```typescript
+// locales/index.ts
+import { defineCatalog } from 'ilingo';
+import en from './en';
+import de from './de';
+
+export const catalog = defineCatalog({ en, de });
+//                                    ^^^^^^^^^^
+// Key<typeof catalog, 'cart'> is 'items', not 'string',
+// because the literal types from each per-locale file are preserved.
+```
 
 ## Authoring plurals: JSON vs TS/JS
 

--- a/docs/src/guide/index.md
+++ b/docs/src/guide/index.md
@@ -46,6 +46,7 @@ The chain is walked **locale-first**: the closest locale beats the farthest one 
 
 | Concept | Page |
 |---|---|
+| Catalog shape + JSON-vs-TS authoring | [Catalog Design](./catalog-design) |
 | Pluggable storage backend | [Stores](./stores) |
 | BCP-47 fallback chain     | [Locales & Fallback](./locales) |
 | `{{var}}` substitution + data merging | [Templates & Data](./templates) |

--- a/docs/src/guide/locales.md
+++ b/docs/src/guide/locales.md
@@ -97,3 +97,12 @@ ilingo.setLocale(negotiateLocale(supported, requested) ?? 'en');
 ```
 
 `parseAcceptLanguage(header)` parses the RFC 9110 header into a quality-sorted array, dropping the `*` wildcard. Tags without an explicit `q=` default to `q=1.0`. Both functions are pure — they don't mutate `Ilingo` state.
+
+## Low-level helpers
+
+`getResolvedLocaleChain` is the supported public surface; the two helpers it composes are also exported for advanced callers (e.g. building a custom resolver that needs the same BCP-47 semantics):
+
+- `bcp47Parents(locale): string[]` — walks `'pt-BR-Latn'` → `['pt-BR-Latn', 'pt-BR', 'pt']`.
+- `resolveLocaleChain(locale, fallback, defaultLocale): string[]` — same algorithm `Ilingo.getResolvedLocaleChain` uses internally, exposed pure for tests and tooling.
+
+You won't need either for typical usage — they exist because the chain logic is useful outside of an `Ilingo` instance.

--- a/docs/src/guide/missing-key.md
+++ b/docs/src/guide/missing-key.md
@@ -25,7 +25,7 @@ Return a **string** to make it the result of `get()`; return **`undefined`** to 
 
 ## Handler context
 
-The handler receives a `MissingKeyContext`:
+The `onMissingKey` field is typed as `MissingKeyHandler = (ctx: MissingKeyContext) => string | undefined`. The handler receives a `MissingKeyContext`:
 
 | Field | Type | Notes |
 |---|---|---|

--- a/docs/src/migration/from-5.0.md
+++ b/docs/src/migration/from-5.0.md
@@ -1,0 +1,153 @@
+# Upgrading from 5.0
+
+This page lists every change since `ilingo@5.0.0` / `@ilingo/fs@5.0.0` / `@ilingo/vue@5.0.0` / `@ilingo/vuelidate@6.0.0` that requires action on your side. New additive features (LoaderStore, formatters, Vue ergonomics, locale negotiation, …) are documented in the matching guide pages and are not repeated here.
+
+If you do not author plural leaves, do not implement a custom `IStore`, and do not call `store.set(...)` directly, your code runs unchanged — skim and move on.
+
+## `ilingo` (core)
+
+### Plural leaves must use the `@plural` wrapper
+
+The bare structural form (a `{ one, other }` object recognised by shape) is gone. Authoring now requires the explicit `@plural` marker.
+
+**Before:**
+
+```typescript
+const catalog = {
+    en: {
+        cart: {
+            items: { one: '1 item', other: '{{count}} items' },
+        },
+    },
+};
+```
+
+**After (JSON):**
+
+```json
+{
+    "cart": {
+        "items": {
+            "@plural": {
+                "one": "1 item",
+                "other": "{{count}} items"
+            }
+        }
+    }
+}
+```
+
+**After (TS):**
+
+```typescript
+import { defineCatalog, definePlural } from 'ilingo';
+
+const catalog = defineCatalog({
+    en: {
+        cart: {
+            items: definePlural({
+                one:   '1 item',
+                other: '{{count}} items',
+            }),
+        },
+    },
+});
+```
+
+Why: the structural form collided with sibling keys named after CLDR categories (e.g. an enum dropdown with an "other" option). The explicit marker eliminates the ambiguity. See [Catalog Design](../guide/catalog-design#authoring-plurals-json-vs-tsjs) for the authoring story.
+
+A bare `{ one, other }` object still type-checks as a regular nested namespace; it just no longer triggers plural selection at lookup. Typed catalogs (`Ilingo<typeof catalog>`) catch the gotcha at compile time — `ilingo.get({ group: 'cart', key: 'items' })` becomes a type error because `items` is no longer a leaf.
+
+### Plural type names: `PluralLeaf` is now the wrapper
+
+The plural-related types and guards renamed in lock-step with the `@plural` change.
+
+| Old name | New name | What it is |
+|---|---|---|
+| `PluralLeaf` | `PluralForms` | inner CLDR options `{ other, zero?, one?, ... }` |
+| `PluralLeafExplicit` | `PluralLeaf` | wrapper `{ '@plural': PluralForms }` (catalog leaf) |
+| `isPluralLeaf` | `isPluralForms` | inner-shape guard |
+| `isPluralLeafExplicit` | `isPluralLeaf` | wrapper guard |
+| `asPluralLeaf` | _(removed)_ | inline `if (isPluralLeaf(v)) return v['@plural']` |
+
+**Before:**
+
+```typescript
+import type { PluralLeaf, PluralLeafExplicit } from 'ilingo';
+import { isPluralLeaf, asPluralLeaf } from 'ilingo';
+
+function handle(value: unknown) {
+    const forms = asPluralLeaf(value);  // accepted either form
+    if (forms) /* ... */;
+}
+```
+
+**After:**
+
+```typescript
+import type { PluralForms, PluralLeaf } from 'ilingo';
+import { isPluralLeaf } from 'ilingo';
+
+function handle(value: unknown) {
+    if (isPluralLeaf(value)) {
+        const forms: PluralForms = value['@plural'];
+        /* ... */
+    }
+}
+```
+
+### Stores are now walked serially within a locale
+
+`Ilingo.lookup` previously issued `Promise.all` across every store in a locale and picked the first declared hit. It now walks stores serially in insertion order and stops at the first hit.
+
+**Observable change:** custom stores after a hit are not called at all. A network-backed adapter registered after a `MemoryStore` is never queried when the Memory store has the key.
+
+**Action required:** only if you have a custom store with side effects (metrics, warm-up, request counting) that depended on being invoked on every key. Move that work behind the store's own logic — inside `get()` — so it fires when the store is actually consulted.
+
+When every registered store would have hit, total latency is now `sum(per-store)` instead of `max(per-store)`. In practice the in-tree adapters are sync after first warm-up, so the worst case rarely fires. See [Stores: Multiple stores](../guide/stores#multiple-stores) for the new contract.
+
+### `StoreSetContext.value` is narrower
+
+`value` you pass to `store.set(...)` must now be `string | PluralLeaf` (the wrapper). Passing the bare `{ one, other }` shape used to silently round-trip (because the structural form was recognised on read) — it no longer does.
+
+**Before:**
+
+```typescript
+await store.set({
+    locale: 'en', group: 'cart', key: 'items',
+    value: { one: '1 item', other: '{{count}} items' },
+});
+```
+
+**After:**
+
+```typescript
+await store.set({
+    locale: 'en', group: 'cart', key: 'items',
+    value: { '@plural': { one: '1 item', other: '{{count}} items' } },
+});
+```
+
+## `@ilingo/fs`
+
+### `FSStore.get` return type widened to `Leaf`
+
+`FSStore.get` was declared `Promise<string | undefined>` while inheriting from `MemoryStore.get` which returns `Promise<Leaf | undefined>`. The override illegally narrowed the return type. It is now `Promise<Leaf | undefined>`, matching the parent.
+
+**Action required:** only if you type-checked the result of `FSStore.get` directly and expected the narrower type. Switch to `Leaf` and discriminate with `typeof v === 'string'`.
+
+## `@ilingo/vue` and `@ilingo/vuelidate`
+
+No breaking changes.
+
+## Quick-check: am I affected?
+
+| Change | Affected if you... |
+|---|---|
+| `@plural` wrapper required | author plural leaves anywhere (JSON or TS) |
+| `PluralLeaf` rename | import any of the renamed types or guards |
+| Serial store walk | run a custom store with side effects |
+| `StoreSetContext.value` narrower | call `store.set(...)` with a plural value directly |
+| `FSStore.get` widening | type-check `FSStore.get` results against `string` |
+
+If none of the above apply, your code runs unchanged.

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -452,6 +452,24 @@ await ilingo.get({ group: 'cart',  key: 'items', count: 1 });  // OK
 
 `defineCatalog<const T>(catalog)` uses TS 5+ const-generic inference so per-key literals (and `@plural`-wrapped plural leaves) aren't widened to `string`. The runtime function is a no-op identity — purely a type carrier.
 
+For one-file-per-locale layouts, reach for `defineLocale<const T extends GroupsRecord>(locale: T): T` — the per-locale companion. It preserves literal types through an `export default` boundary and validates that the body is a `GroupsRecord` (catching a stray top-level string that `as const` would let through). Combine with `defineCatalog` to merge per-locale files into a single typed catalog:
+
+```typescript
+// locales/en.ts
+import { defineLocale, definePlural } from 'ilingo';
+
+export default defineLocale({
+    app:  { greeting: 'Hi {{name}}' },
+    cart: { items: definePlural({ one: '1 item', other: '{{count}} items' }) },
+});
+
+// locales/index.ts
+import { defineCatalog } from 'ilingo';
+import en from './en';
+import de from './de';
+export const catalog = defineCatalog({ en, de });
+```
+
 Inference is structural, derived from the union of locales. Keep all locales aligned to the same shape and the inferred `Key<C, G>` is the natural set of leaf paths. Diverging locales widen the union but never break compilation.
 
 `new Ilingo()` (no generic) preserves today's loose typing — `group: string, key: string` are accepted. The generic is opt-in.

--- a/packages/ilingo/src/catalog.ts
+++ b/packages/ilingo/src/catalog.ts
@@ -5,7 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { LocalesRecord, PluralForms, PluralLeaf } from './types';
+import type { 
+    GroupsRecord, 
+    LocalesRecord, 
+    PluralForms, 
+    PluralLeaf, 
+} from './types';
 
 /**
  * Helper that returns its argument unchanged but captures it with `const`
@@ -26,6 +31,36 @@ import type { LocalesRecord, PluralForms, PluralLeaf } from './types';
  */
 export function defineCatalog<const T extends LocalesRecord>(catalog: T): T {
     return catalog;
+}
+
+/**
+ * One-file-per-locale companion to `defineCatalog`. Captures the groups
+ * for a single locale with `const` inference so the per-key literal types
+ * survive an `export default`, and validates the shape against
+ * `GroupsRecord` so a misplaced top-level value (a stray string, the
+ * wrong nesting) is caught at compile time instead of failing silently
+ * at lookup.
+ *
+ * Combine multiple `defineLocale` files via `defineCatalog` — the const
+ * generics flow through, so `Ilingo<typeof catalog>` still infers the
+ * full set of legal `(group, key)` pairs.
+ *
+ * @example
+ *     // locales/en.ts
+ *     import { defineLocale, definePlural } from 'ilingo';
+ *
+ *     export default defineLocale({
+ *         app:  { greeting: 'Hi {{name}}' },
+ *         cart: { items: definePlural({ one: '1 item', other: '{{count}} items' }) },
+ *     });
+ *
+ *     // locales/index.ts
+ *     import en from './en';
+ *     import de from './de';
+ *     export const catalog = defineCatalog({ en, de });
+ */
+export function defineLocale<const T extends GroupsRecord>(locale: T): T {
+    return locale;
 }
 
 /**

--- a/packages/ilingo/test/unit/types.spec-d.ts
+++ b/packages/ilingo/test/unit/types.spec-d.ts
@@ -10,7 +10,7 @@ import type {
     Formatter, MissingKeyContext, MissingKeyHandler,
 } from '../../src';
 import {
-    Ilingo, MemoryStore, defineCatalog, definePlural,
+    Ilingo, MemoryStore, defineCatalog, defineLocale, definePlural,
 } from '../../src';
 
 // A typical typed catalog mixing flat keys, nested namespaces, and
@@ -253,6 +253,60 @@ describe('defineCatalog — preserves narrow inference', () => {
         expectTypeOf<keyof typeof c>().toEqualTypeOf<'en'>();
         expectTypeOf<keyof (typeof c)['en']>().toEqualTypeOf<'app'>();
         expectTypeOf<keyof (typeof c)['en']['app']>().toEqualTypeOf<'greeting'>();
+    });
+});
+
+describe('defineLocale — one-file-per-locale authoring', () => {
+    it('keeps per-key literal types through an export-default round-trip', () => {
+        // Simulates a `locales/en.ts` file authored with defineLocale.
+        const en = defineLocale({
+            app:  { greeting: 'Hi' },
+            cart: { items: definePlural({ one: '1', other: '{{count}}' }) },
+        });
+
+        expectTypeOf<keyof typeof en>().toEqualTypeOf<'app' | 'cart'>();
+        expectTypeOf<keyof (typeof en)['app']>().toEqualTypeOf<'greeting'>();
+        // Plural leaves keep the `@plural` discriminator at the type level.
+        expectTypeOf<keyof (typeof en)['cart']['items']>().toEqualTypeOf<'@plural'>();
+    });
+
+    it('composes with defineCatalog, preserving inference through the seams', () => {
+        // The point of the helper: const inference flows from the per-locale
+        // file into the combined catalog without `as const` sprinkling.
+        const en = defineLocale({
+            app:  { greeting: 'Hi' },
+            cart: { items: definePlural({ one: '1', other: '{{count}}' }) },
+        });
+        const de = defineLocale({
+            app:  { greeting: 'Hallo' },
+            cart: { items: definePlural({ one: 'Artikel', other: '{{count}} Artikel' }) },
+        });
+
+        const catalog = defineCatalog({ en, de });
+        const ilingo = new Ilingo<typeof catalog>({
+            store: new MemoryStore({ data: catalog }),
+        });
+
+        ilingo.get({ group: 'app', key: 'greeting' });
+        ilingo.get({ group: 'cart', key: 'items', count: 1 });
+
+        ilingo.get({
+            group: 'app',
+            // @ts-expect-error 'unknown' is not a key of the `app` group
+            key: 'unknown',
+        });
+        // @ts-expect-error count is required for plural keys
+        ilingo.get({ group: 'cart', key: 'items' });
+    });
+
+    it('rejects a non-GroupsRecord shape at compile time', () => {
+        // A stray top-level string isn't a valid group body — must be a
+        // `LinesRecord` (nested object). The const generic constraint
+        // catches this where `as const` would not.
+        defineLocale({
+            // @ts-expect-error top-level string is not a GroupsRecord entry
+            app: 'oops, that should have been { greeting: "..." }',
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

Three Track C items from the stability roadmap (#917) bundled into one focused docs PR. The fourth Track C item — the SSR integration recipe — is intentionally deferred to its own PR since it stands alone.

### 1. New "Catalog Design" guide page

`docs/src/guide/catalog-design.md` synthesizes content previously scattered across the README and `pluralization.md` / `type-safe-keys.md`. Covers:

- Catalog shape recap (locale → group → nested record of leaves).
- File-layout patterns: one-file-per-locale vs one-file-per-(locale,group).
- `defineCatalog` and why it beats `as const` sprinkling.
- Plural authoring in JSON vs TS — `@plural` literal vs `definePlural` helper.
- The explicit "bare `{ one, other }` is not a plural" semantics (catches the silent-rename gotcha for typed catalogs).

Wired into the **Concepts** sidebar between Overview and Stores; cross-linked from the guide index.

### 2. New "Upgrading from 5.0" migration page

`docs/src/migration/from-5.0.md`. Originally drafted as "Upgrading to Stable" — trimmed to scope: only breaking changes since the published `5.0.0`, no recap of additive features (those live in their matching guide pages).

Covers:

- `@plural` wrapper required (was: bare structural form accepted).
- Plural type/guard renames (`PluralLeaf` is now the wrapper; `PluralForms` is the inner shape).
- Serial store walk within a locale (was: `Promise.all` parallel).
- `StoreSetContext.value` narrowed to `string | PluralLeaf`.
- `FSStore.get` return type widened to `Leaf` (was: illegally narrowed to `string`).

Each entry has a before/after snippet. New top-level **Migration** nav entry.

### 3. Doc-anchor audit

Every public symbol mentioned in a package README has at least one anchor on the docs site. Two real gaps surfaced and were patched:

- `MissingKeyHandler` — now referenced alongside `MissingKeyContext` in `missing-key.md`.
- `bcp47Parents` + `resolveLocaleChain` — now documented under a "Low-level helpers" section in `locales.md`.

Everything else was already covered. (The audit was run with a generated symbol list from each `src/index.ts`.)

## Test plan

- [x] `npm run build -w @ilingo/docs` — VitePress build is green.
- [x] Sidebar entries appear under Concepts (Catalog Design) and the new Migration top-level nav.
- [x] All internal cross-links (`./catalog-design`, `./type-safe-keys`, `./pluralization`, `../guide/...`) resolve.
- [ ] CI green on PR.

Plan file (`.agents/plans/007-stability-roadmap.md`) ticks off the three Track C items.