### PR TITLE
docs: SSR integration recipe (Nuxt + Astro)

### DIFF
--- a/.agents/plans/007-stability-roadmap.md
+++ b/.agents/plans/007-stability-roadmap.md
@@ -26,7 +26,7 @@ Each decision lands as a commit (often docs-only) that nails the contract. Items
 
 - [x] **`catalog-design` guide page** covering `defineCatalog` / `definePlural` workflow + JSON-vs-TS authoring trade-offs. Lives at `docs/src/guide/catalog-design.md`; wired into the "Concepts" sidebar between Overview and Stores. Cross-linked from the overview page.
 - [x] **Migration guide** enumerating breaking changes since `5.0.0`. Originally framed as "Upgrading to Stable" but trimmed to "From 5.0" — a focused list of breakages a consumer would hit upgrading from the published 5.0.0 to whatever the next release cuts. Purely-additive features are not duplicated here; they live in the matching guide pages. Lives at `docs/src/migration/from-5.0.md` under a new top-level Migration nav entry.
-- [ ] **SSR integration recipe** — at least one. Nuxt is the obvious target since `vue-i18n`'s strongest consumer story is there. Astro is a strong second.
+- [x] **SSR integration recipe.** Lives at `docs/src/recipes/ssr.md` under a new top-level "Recipes" nav entry. Four framework-agnostic building blocks (per-request `Ilingo`, locale negotiation, `LoaderStore` for lazy locales, hydration patterns A and B) followed by concrete Nuxt and Astro slots and an edge-runtime note. Cross-linked from `guide/locales.md` so SSR users land on the recipe from the locale-negotiation section.
 - [x] **Doc-anchor audit** — every public symbol mentioned in a package README has at least one anchor on the docs site. Gaps that surfaced and were patched: `MissingKeyHandler` (now referenced in `missing-key.md` alongside the existing `MissingKeyContext` table), `bcp47Parents` + `resolveLocaleChain` (now under a "Low-level helpers" section in `locales.md`).
 
 ## Track D — Test + benchmark floor

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -180,6 +180,7 @@ docs/
     │   └── quick-start.md
     ├── guide/
     │   ├── index.md          # conceptual overview + sitemap
+    │   ├── catalog-design.md
     │   ├── stores.md
     │   ├── locales.md
     │   ├── templates.md
@@ -187,11 +188,15 @@ docs/
     │   ├── formatters.md
     │   ├── type-safe-keys.md
     │   └── missing-key.md
-    └── integrations/
-        ├── index.md
-        ├── fs.md
-        ├── vue.md
-        └── vuelidate.md
+    ├── integrations/
+    │   ├── index.md
+    │   ├── fs.md
+    │   ├── vue.md
+    │   └── vuelidate.md
+    ├── recipes/
+    │   └── ssr.md            # per-request Ilingo, hydration, Nuxt + Astro slots
+    └── migration/
+        └── from-5.0.md       # breaking-change list since the published 5.0.0
 ```
 
 The sidebar in `config.mts` is the source of truth for what pages should exist — adding a markdown file under `src/guide/` is not enough, it must also be referenced in the sidebar config.

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
             { text: 'Getting Started', link: '/getting-started/', activeMatch: '/getting-started/' },
             { text: 'Guide', link: '/guide/', activeMatch: '/guide/' },
             { text: 'Integrations', link: '/integrations/', activeMatch: '/integrations/' },
+            { text: 'Recipes', link: '/recipes/ssr', activeMatch: '/recipes/' },
             { text: 'Migration', link: '/migration/from-5.0', activeMatch: '/migration/' },
         ],
         sidebar: {
@@ -71,6 +72,12 @@ export default defineConfig({
                     { text: 'File System', link: '/integrations/fs' },
                     { text: 'Vue', link: '/integrations/vue' },
                     { text: 'Vuelidate', link: '/integrations/vuelidate' },
+                ],
+            }],
+            '/recipes/': [{
+                text: 'Recipes',
+                items: [
+                    { text: 'Server-Side Rendering', link: '/recipes/ssr' },
                 ],
             }],
             '/migration/': [{

--- a/docs/src/guide/locales.md
+++ b/docs/src/guide/locales.md
@@ -98,6 +98,8 @@ ilingo.setLocale(negotiateLocale(supported, requested) ?? 'en');
 
 `parseAcceptLanguage(header)` parses the RFC 9110 header into a quality-sorted array, dropping the `*` wildcard. Tags without an explicit `q=` default to `q=1.0`. Both functions are pure — they don't mutate `Ilingo` state.
 
+For the full per-request pattern (avoiding a global `Ilingo`, hydrating from server to client, slotting into Nuxt or Astro), see [Recipes → Server-Side Rendering](../recipes/ssr).
+
 ## Low-level helpers
 
 `getResolvedLocaleChain` is the supported public surface; the two helpers it composes are also exported for advanced callers (e.g. building a custom resolver that needs the same BCP-47 semantics):

--- a/docs/src/recipes/ssr.md
+++ b/docs/src/recipes/ssr.md
@@ -1,0 +1,267 @@
+# Server-Side Rendering
+
+Running ilingo through an SSR pipeline introduces three concerns:
+
+1. **Per-request state.** Every incoming request can ask for a different locale. The `Ilingo` instance must not leak that state between requests on a long-lived server.
+2. **Locale negotiation.** The locale isn't known until the request arrives — it has to be derived from `Accept-Language`, a cookie, a URL segment, or a combination.
+3. **Hydration.** The client should render the translated HTML without re-fetching every locale file. Whatever the server resolved should be handed to the client.
+
+The library ships every piece you need (`negotiateLocale`, `parseAcceptLanguage`, `Ilingo.clone`, `LoaderStore`), and stays framework-agnostic. This page shows the building blocks first, then sketches how each one slots into Nuxt and Astro.
+
+## Building blocks
+
+### 1. Build a fresh instance per request
+
+The orchestrator is cheap to construct. Each request gets its own `Ilingo` so a `setLocale` from one request can't leak into another. The translation **data** (your catalog) stays shared — only the per-request configuration changes.
+
+```typescript
+// server/ilingo-factory.ts
+import { Ilingo, MemoryStore, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+import { catalog } from '../locales';
+
+const SUPPORTED = ['en', 'de', 'pt-BR'] as const;
+const DEFAULT   = 'en';
+
+// One store, shared. No per-request mutation here.
+const store = new MemoryStore({ data: catalog });
+
+export function ilingoForRequest(headers: { 'accept-language'?: string }): Ilingo {
+    const requested = parseAcceptLanguage(headers['accept-language'] ?? '');
+    const locale    = negotiateLocale(SUPPORTED, requested) ?? DEFAULT;
+
+    return new Ilingo<typeof catalog>({ store, locale });
+}
+```
+
+A cookie or URL-segment locale wins over `Accept-Language` if your app supports user-preference persistence — flow it into the same call:
+
+```typescript
+export function ilingoForRequest(
+    headers: { 'accept-language'?: string },
+    cookies: { locale?: string },
+): Ilingo {
+    const explicit = cookies.locale && SUPPORTED.includes(cookies.locale as typeof SUPPORTED[number])
+        ? cookies.locale
+        : undefined;
+    const requested = parseAcceptLanguage(headers['accept-language'] ?? '');
+    const locale    = explicit ?? negotiateLocale(SUPPORTED, requested) ?? DEFAULT;
+
+    return new Ilingo<typeof catalog>({ store, locale });
+}
+```
+
+See [Locales & Fallback → Negotiating a locale from a request](../guide/locales#negotiating-a-locale-from-a-request) for the matcher semantics.
+
+### 2. Avoid a global `Ilingo`
+
+The temptation is to spin up a single module-scope `Ilingo` and call `setLocale` per request. That works in single-tenant CLIs and serverless `event` handlers — it breaks on a long-lived Node server because two concurrent requests race on the locale field.
+
+```typescript
+// ❌ Don't — shared mutable locale on a long-lived server
+const ilingo = new Ilingo({ store, locale: 'en' });
+
+server.use((req, _res, next) => {
+    ilingo.setLocale(req.locale);   // overwrites whatever the other in-flight request had
+    next();
+});
+```
+
+```typescript
+// ✅ Do — one instance per request
+server.use((req, _res, next) => {
+    req.ilingo = ilingoForRequest(req.headers, req.cookies);
+    next();
+});
+```
+
+The factory is allocation-light: it constructs a per-instance plural-rules cache, a missing-key warn set, and a formatter registry — nothing else. The underlying `MemoryStore` and its catalog are shared.
+
+### 3. Lazy-load locales with `LoaderStore`
+
+For catalogs that ship one chunk per locale, `LoaderStore` lets a request only pull the locale it actually needs. The first request for `de` loads `./locales/de.json`; subsequent requests hit the in-memory cache.
+
+```typescript
+import { Ilingo, LoaderStore, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+
+const store = new LoaderStore({
+    locales: ['en', 'de', 'pt-BR'],
+    loader: async (locale, group) => {
+        // group is your logical namespace; usually you ship one file per
+        // (locale, group) pair. For a single file per locale, fold the
+        // group into the path or ignore it.
+        const mod = await import(`../locales/${locale}/${group}.json`);
+        return mod.default;
+    },
+});
+
+export function ilingoForRequest(headers: { 'accept-language'?: string }) {
+    const requested = parseAcceptLanguage(headers['accept-language'] ?? '');
+    const locale    = negotiateLocale(['en', 'de', 'pt-BR'], requested) ?? 'en';
+    return new Ilingo({ store, locale });
+}
+```
+
+The cache is shared across requests — that's the win. Misses (loader returning `undefined`) are cached too, so a typo in a request doesn't repeatedly hammer the loader. See [Stores → Loader Store](../guide/stores#loader-store) for the contract.
+
+### 4. Hand state to the client
+
+Serialise *only what the client needs* into the HTML, then rebuild on the client. Two flavours, depending on whether the client has the full catalog or just the rendered strings:
+
+#### Pattern A — same catalog on both sides
+
+When the client bundle already ships the catalog (small apps, JSON catalogs that gzip well), the server only needs to tell the client which locale it chose:
+
+```html
+<script type="application/json" id="__ilingo">
+    {"locale": "de"}
+</script>
+```
+
+```typescript
+// client
+import { Ilingo, MemoryStore } from 'ilingo';
+import { catalog } from './locales';
+
+const initial = JSON.parse(document.getElementById('__ilingo')!.textContent!);
+const ilingo  = new Ilingo<typeof catalog>({
+    store: new MemoryStore({ data: catalog }),
+    locale: initial.locale,
+});
+```
+
+#### Pattern B — server picks slices, client receives them
+
+For larger catalogs you serialise the slice the client needs (e.g. only the locale that was negotiated, or only the groups rendered into the initial page). The client builds an `Ilingo` over the slice:
+
+```typescript
+// server-side render
+const ilingo = ilingoForRequest(req.headers, req.cookies);
+const locale = ilingo.getLocale();
+
+// Pull only the slice needed for hydration.
+const slice = {
+    [locale]: await loadFullLocaleFromCatalog(locale),
+};
+
+res.send(renderShell({
+    html:   renderApp(ilingo),
+    state:  JSON.stringify({ locale, slice }),
+}));
+```
+
+```typescript
+// client
+const { locale, slice } = JSON.parse(document.getElementById('__ilingo')!.textContent!);
+const ilingo = new Ilingo({
+    store:  new MemoryStore({ data: slice }),
+    locale,
+});
+```
+
+A common refinement: ship `slice` as `data` to `MemoryStore`, and *also* add a `LoaderStore` for the other locales. The user switching locale post-hydration triggers the loader; the initial render never pays for the others.
+
+```typescript
+const ilingo = new Ilingo({
+    locale,
+    store: new MemoryStore({ data: slice }),
+});
+ilingo.stores.add(new LoaderStore({
+    locales: ['en', 'de', 'pt-BR'],
+    loader: (loc, group) => import(`./locales/${loc}/${group}.json`).then((m) => m.default),
+}));
+// MemoryStore answers first (already-hydrated locale); LoaderStore covers everything else.
+// The serial store walk (#917 Track B) means LoaderStore never fires for keys MemoryStore has.
+```
+
+## Nuxt
+
+Nuxt's request lifecycle gives you `useRequestEvent()` on the server and `useState()` for hydration. The pattern slots in via a plugin that runs on both sides.
+
+```typescript
+// plugins/ilingo.ts
+import { Ilingo, MemoryStore, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+import { install } from '@ilingo/vue';
+import { catalog } from '~/locales';
+
+const SUPPORTED = ['en', 'de'];
+
+export default defineNuxtPlugin((nuxtApp) => {
+    // useState gives a value that's serialised into payload on the server
+    // and re-read on the client — exactly the hydration channel we want.
+    const initial = useState<{ locale: string }>('ilingo', () => {
+        if (import.meta.server) {
+            const event   = useRequestEvent();
+            const header  = getRequestHeader(event!, 'accept-language') ?? '';
+            const wanted  = parseAcceptLanguage(header);
+            return { locale: negotiateLocale(SUPPORTED, wanted) ?? 'en' };
+        }
+        return { locale: 'en' }; // hydration overrides this from payload
+    });
+
+    const ilingo = new Ilingo<typeof catalog>({
+        store:  new MemoryStore({ data: catalog }),
+        locale: initial.value.locale,
+    });
+
+    install(nuxtApp.vueApp, ilingo);
+});
+```
+
+On the server, `useState` reads from the request and seeds the payload. On the client, `useState` reads from the serialised payload — Nuxt handles the wiring. Both branches build the same `Ilingo` shape, so SSR'd HTML matches the first client render.
+
+For cookie-based locale persistence, replace the negotiation block with `useCookie('locale').value ?? negotiateLocale(...)`. For catalog chunking, swap `MemoryStore` for `LoaderStore` and feed `Nuxt's import()`-based dynamic imports into the loader.
+
+A community Nuxt module isn't shipped in-tree — the plugin above is intentionally framework-thin so it works against Nuxt 3 / Nuxt 4 / any future variant without a versioned coupling.
+
+## Astro
+
+Astro's middleware attaches data to `Astro.locals`. Build the `Ilingo` there, then expose translated strings as props or via a context-style helper.
+
+```typescript
+// src/middleware.ts
+import { defineMiddleware } from 'astro:middleware';
+import { Ilingo, MemoryStore, negotiateLocale, parseAcceptLanguage } from 'ilingo';
+import { catalog } from './locales';
+
+const SUPPORTED = ['en', 'de'];
+const store = new MemoryStore({ data: catalog });
+
+export const onRequest = defineMiddleware((context, next) => {
+    const header  = context.request.headers.get('accept-language') ?? '';
+    const wanted  = parseAcceptLanguage(header);
+    const locale  = negotiateLocale(SUPPORTED, wanted) ?? 'en';
+
+    context.locals.ilingo = new Ilingo<typeof catalog>({ store, locale });
+    return next();
+});
+```
+
+```typescript
+// src/env.d.ts
+/// <reference types="astro/client" />
+declare namespace App {
+    interface Locals {
+        ilingo: import('ilingo').Ilingo;
+    }
+}
+```
+
+```astro
+---
+// src/pages/index.astro
+const greeting = await Astro.locals.ilingo.get({ group: 'app', key: 'greeting' });
+---
+<h1>{greeting}</h1>
+```
+
+For interactive islands (`client:*` directives) the same hydration patterns from [§4](#4-hand-state-to-the-client) apply: serialise the locale + the slice into a `<script type="application/json">` block, build a fresh `Ilingo` in the island's client entry.
+
+## Edge runtimes
+
+The `Ilingo` runtime is pure JavaScript: no `node:fs`, no `node:process` outside the optional `NODE_ENV` guard (which is replaced at build time by every modern bundler). Cloudflare Workers, Vercel Edge, Bun, and Deno all run the core unmodified. `@ilingo/fs` is the exception — it imports `node:fs/promises` and only works on a runtime with the Node filesystem APIs. If you need translations at the edge, ship them in the bundle (`MemoryStore` with an inlined catalog) or fetch them on demand via `LoaderStore` against an external API.
+
+## See also
+
+- [Locales & Fallback](../guide/locales) — `negotiateLocale` / `parseAcceptLanguage` and the fallback-chain matcher.
+- [Stores](../guide/stores) — `MemoryStore`, `LoaderStore`, and the serial-on-miss composition.
+- [Integrations → Vue](../integrations/vue) — what `install()` does and how `useTranslation` consumes the per-request instance.


### PR DESCRIPTION
## Summary

Closes the last Track C item on the stability roadmap (#917): the SSR integration recipe.

New page at `docs/src/recipes/ssr.md`, under a new top-level **Recipes** nav entry. Structure mirrors how the SSR problem actually decomposes:

1. **Building blocks** (framework-agnostic):
   - Build a fresh `Ilingo` per request — the orchestrator is cheap; the catalog/`MemoryStore` stays shared.
   - Why a global `Ilingo.setLocale` races on a long-lived server (✅/❌ snippets).
   - `LoaderStore` for lazy locale chunks — cache is shared across requests; misses are cached too.
   - Two hydration patterns: same-catalog-both-sides (Pattern A) vs server-picks-slices + `LoaderStore` for the rest (Pattern B).

2. **Framework slots:**
   - **Nuxt** — `defineNuxtPlugin` + `useState` for the hydration channel, `useRequestEvent()` for `Accept-Language` on the server. Cookie / catalog-chunking variations called out.
   - **Astro** — `astro:middleware` attaches the instance to `Astro.locals`, with the `App.Locals` type-augmentation snippet. Island hydration falls back to Pattern B.

3. **Edge-runtime note** — the core is pure JS (no `node:*` outside the optional `NODE_ENV` guard). Cloudflare Workers / Vercel Edge / Bun / Deno run unmodified; `@ilingo/fs` is the exception.

Cross-linked from `guide/locales.md` so SSR users land on the recipe from the natural starting point (`negotiateLocale` + `parseAcceptLanguage`). No in-tree Nuxt module ships — the plugin example is intentionally thin so it works against Nuxt 3 / 4 / future without a versioned coupling.

## Track C status after this lands

| Item | Status |
|---|---|
| catalog-design guide | ✅ (PR #927) |
| Migration guide from 5.0 | ✅ (PR #927) |
| SSR integration recipe | ✅ this PR |
| Doc-anchor audit | ✅ (PR #927) |

Track C closed. Remaining roadmap work is Tracks D (test/benchmark floor), E (bundle/browser story), F (ecosystem decisions).

## Test plan

- [x] `npm run build -w @ilingo/docs` — VitePress build is green.
- [x] New "Recipes" nav entry appears between Integrations and Migration.
- [x] All internal cross-links resolve (`../guide/locales`, `../guide/stores`, `../integrations/vue`).
- [ ] CI green on PR.

Plan + structure agent docs updated.