### PR TITLE
build(test): coverage thresholds per package, enforced in CI

### DIFF
--- a/.agents/plans/007-stability-roadmap.md
+++ b/.agents/plans/007-stability-roadmap.md
@@ -31,7 +31,7 @@ Each decision lands as a commit (often docs-only) that nails the contract. Items
 
 ## Track D — Test + benchmark floor
 
-- [ ] **Vitest coverage thresholds** per package. Coverage data is collected today (provider `v8`, `include: ['src/**/*.{ts,tsx,js,jsx}']`) but no thresholds → regressions silent. Pick a floor from current numbers; ratchet over time.
+- [x] **Vitest coverage thresholds** per package. Floors set in each package's `test/vitest.config.ts` with ~5pp headroom on most metrics (10pp on the noisier branch metric in `@ilingo/fs` and `@ilingo/vue`). CI now runs `npm run test:coverage` so threshold violations fail the build. Policy + per-package numbers documented in `.agents/testing.md`. `@ilingo/vuelidate` skipped — no unit suite there.
 - [ ] **Benchmark suite** (`packages/ilingo/bench/`) via `vitest bench`. Cover: cache-hit `get()`, cache-miss with 3-deep fallback, plural lookup, template render with one `number` modifier. Numbers land on a docs Performance page; re-run in CI on every release-please PR.
 - [ ] **Comparative numbers** vs `i18next` and `vue-i18n` for the same workloads — backs up the "lightweight alternative" README claim with receipts.
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -106,7 +106,23 @@ For a custom `IStore` adapter under test, write a tiny class implementing `IStor
 
 ## Code Coverage
 
-`packages/ilingo/package.json` defines `test:coverage` (`vitest run --coverage`). No coverage thresholds are enforced today; reports are informational.
+Each unit-tested package (`ilingo`, `@ilingo/fs`, `@ilingo/vue`) defines a `test:coverage` script that runs `vitest --coverage`. Provider is `v8`; the report includes `src/**/*.{ts,tsx,js,jsx,vue}` per package. Run the full suite from the repo root with `npm run test:coverage` (Nx orchestrates one workspace at a time and caches the results).
+
+### Thresholds
+
+Each `test/vitest.config.ts` carries a `coverage.thresholds` block. The floors are picked from the current baseline minus a few percentage points of headroom so routine churn doesn't fail CI:
+
+| Package | Statements | Branches | Functions | Lines |
+|---|---|---|---|---|
+| `ilingo` | 90 | 80 | 85 | 90 |
+| `@ilingo/fs` | 85 | 60 | 80 | 85 |
+| `@ilingo/vue` | 75 | 65 | 75 | 75 |
+
+`@ilingo/vuelidate` has no unit suite (playground only); skipped.
+
+The `@ilingo/fs` branch floor is intentionally loose — FSStore has many optional code paths (`watch: true`, multi-directory, chokidar peer detection) that only fire under specific configs and are exercised by tests selectively. `@ilingo/vue` trails core because `<ITranslate>` is exercised through the playground rather than the unit suite, and reactive paths through `computedAsync` don't always fire in happy-dom.
+
+CI runs `npm run test:coverage`, so threshold violations fail the build. Treat the thresholds as a ratchet — when sustained baseline moves above the floor, raise the floor in the same PR that benefits from it. Don't lower a threshold to keep CI green; investigate why the previous floor became hard to hit.
 
 ## Infrastructure
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,4 +62,4 @@ jobs:
                 with:
                     node-version: ${{ matrix.node-version }}
             -   uses: ./.github/actions/build
-            -   run: npm run test
+            -   run: npm run test:coverage

--- a/nx.json
+++ b/nx.json
@@ -8,7 +8,7 @@
         "default": {
             "runner": "nx/tasks-runners/default",
             "options": {
-                "cacheableOperations": ["build", "lint", "test"]
+                "cacheableOperations": ["build", "lint", "test", "test:coverage"]
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "@tada5hi/eslint-config": "^2.3.0",
                 "@tada5hi/tsconfig": "^0.7.2",
                 "@types/node": "^25.0.8",
+                "@vitest/coverage-v8": "^4.1.7",
                 "cross-env": "^10.1.0",
                 "eslint": "^10.3.0",
                 "eslint-plugin-vue": "^10.9.1",
@@ -381,9 +382,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -428,6 +429,16 @@
             "license": "MIT",
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@commitlint/cli": {
@@ -3207,6 +3218,37 @@
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitest/coverage-v8": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+            "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^1.0.2",
+                "@vitest/utils": "4.1.7",
+                "ast-v8-to-istanbul": "^1.0.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.2.0",
+                "magicast": "^0.5.2",
+                "obug": "^2.1.1",
+                "std-env": "^4.0.0-rc.1",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "4.1.7",
+                "vitest": "4.1.7"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@vitest/expect": {
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
@@ -4072,6 +4114,25 @@
             "funding": {
                 "url": "https://github.com/sponsors/sxzz"
             }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
+            "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -6141,6 +6202,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/html-void-elements": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -6457,6 +6525,45 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/jackspeak": {
             "version": "3.4.3",
@@ -7069,6 +7176,74 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.3",
+                "@babel/types": "^7.29.0",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/magicast/node_modules/@babel/helper-string-parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/magicast/node_modules/@babel/parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.7"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/magicast/node_modules/@babel/types": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mark.js": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@tada5hi/eslint-config": "^2.3.0",
         "@tada5hi/tsconfig": "^0.7.2",
         "@types/node": "^25.0.8",
+        "@vitest/coverage-v8": "^4.1.7",
         "cross-env": "^10.1.0",
         "eslint": "^10.3.0",
         "eslint-plugin-vue": "^10.9.1",
@@ -58,6 +59,7 @@
     "scripts": {
         "build": "npx nx run-many -t build",
         "test": "npx nx run-many -t test",
+        "test:coverage": "npx nx run-many -t test:coverage",
         "lint": "eslint",
         "lint:fix": "npm run lint -- --fix",
         "prepare": "husky"

--- a/packages/fs/test/vitest.config.ts
+++ b/packages/fs/test/vitest.config.ts
@@ -6,6 +6,16 @@ export default defineConfig({
         coverage: {
             provider: 'v8',
             include: ['src/**/*.{ts,tsx,js,jsx}'],
+            // Branch threshold is intentionally loose: FSStore has many
+            // optional code paths (watch mode, multi-directory, chokidar
+            // peer detection) that fire only under specific configs.
+            // See `.agents/testing.md` for the policy.
+            thresholds: {
+                statements: 85,
+                branches:   60,
+                functions:  80,
+                lines:      85,
+            },
         },
     },
 });

--- a/packages/ilingo/test/vitest.config.ts
+++ b/packages/ilingo/test/vitest.config.ts
@@ -13,6 +13,16 @@ export default defineConfig({
         coverage: {
             provider: 'v8',
             include: ['src/**/*.{ts,tsx,js,jsx}'],
+            // Floors picked from current numbers with ~5pp headroom for
+            // routine churn; tighter thresholds get ratcheted up manually
+            // when a sustained baseline emerges. See `.agents/testing.md`
+            // for the policy.
+            thresholds: {
+                statements: 90,
+                branches:   80,
+                functions:  85,
+                lines:      90,
+            },
         },
     },
 });

--- a/packages/vue/test/vitest.config.ts
+++ b/packages/vue/test/vitest.config.ts
@@ -9,6 +9,17 @@ export default defineConfig({
         coverage: {
             provider: 'v8',
             include: ['src/**/*.{ts,tsx,vue}'],
+            // Vue coverage trails core because the `<ITranslate>` SFC is
+            // exercised through the playground, not the unit suite, and
+            // composable code has reactive paths that don't always fire
+            // in jsdom-style tests. Thresholds set to current baseline
+            // minus ~10pp headroom; ratchet up as the suite grows.
+            thresholds: {
+                statements: 75,
+                branches:   65,
+                functions:  75,
+                lines:      75,
+            },
         },
     },
 });


### PR DESCRIPTION
## Summary

First Track D item on the stability roadmap (#917). Coverage data was collected but informational — regressions could slip through silently because nothing failed the build. Each package now declares a floor in `test/vitest.config.ts`, and CI runs `npm run test:coverage` so threshold violations are caught.

### Floors

Picked from current baseline with ~5pp headroom on most metrics, ~10pp on the noisier branch metric in fs/vue:

| Package | Statements | Branches | Functions | Lines | Current |
|---|---|---|---|---|---|
| `ilingo` | 90 | 80 | 85 | 90 | 95.46 / 88.75 / 91.54 / 96.24 |
| `@ilingo/fs` | 85 | 60 | 80 | 85 | 90.00 / 65.45 / 88.88 / 91.42 |
| `@ilingo/vue` | 75 | 65 | 75 | 75 | 83.52 / 74.31 / 85.71 / 84.47 |

`@ilingo/vuelidate` is skipped — no unit suite, playground only.

### Why the looser branch floors

- **`@ilingo/fs`**: FSStore has many optional code paths (`watch: true`, multi-directory, chokidar peer detection) that only fire under specific configs. Branch coverage there reflects which features are exercised, not test thoroughness.
- **`@ilingo/vue`**: `<ITranslate>` is exercised through the playground rather than the unit suite, and reactive paths through `computedAsync` don't always fire in happy-dom.

### Wiring

- Root `package.json` gains `"test:coverage": "npx nx run-many -t test:coverage"`.
- `nx.json` adds `test:coverage` to cacheable operations.
- CI workflow's tests job now runs `npm run test:coverage` instead of `npm run test`.
- `@vitest/coverage-v8` added to workspace devDeps (was missing — `npm run test:coverage` failed locally with "MISSING DEPENDENCY" before this PR).

### Policy

Treat thresholds as a **ratchet**: raise the floor in the same PR that improves coverage. Don't lower a threshold to keep CI green — investigate why the previous floor became hard to hit. Recorded in `.agents/testing.md`.

## Test plan

- [x] `npm run test:coverage` from repo root — all three packages pass thresholds.
- [x] Per-package `npm run test:coverage --workspace=packages/<x>` works individually.
- [x] Existing fast `npm run test` still works for local iteration (no coverage overhead).
- [ ] CI green on PR.

Plan ticked. Remaining Track D items: benchmark suite (`vitest bench`) + comparative numbers vs `i18next` / `vue-i18n`.