### PR TITLE
build: declare sideEffects:false on all four published packages

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -115,6 +115,15 @@ Conventional Commits, validated by commitlint:
 - Source maps are emitted (`sourcemap: true` in `tsdown.config.ts`).
 - The `files` field in each `package.json` controls what is published — `dist/` plus any pre-built subpath dirs (`core/`, `vue/`).
 
+### Tree-shaking — `sideEffects: false`
+
+Every published package declares `"sideEffects": false` in its `package.json` so Vite / webpack / Rollup can drop unused exports from a consumer's bundle. The audit that backed this (#917 Track E) confirmed no top-level side effects in any `src/` file: no module-scope `console.*`, no global mutations, no prototype patching, no CSS imports, no bare effectful imports. The single Vue SFC (`@ilingo/vue/src/component.vue`) has no `<style>` block.
+
+When adding new source files, keep this contract:
+
+- **OK**: function/class declarations, constants, JSON imports as values, lazy-imports inside function bodies (e.g. `FSStore`'s lazy `chokidar` import).
+- **Not OK without flipping the field**: top-level statements that run on import (registering globals, mutating prototypes, side-effect-only imports like `import 'some-polyfill'`, CSS imports). If you genuinely need any of these, change the package's `sideEffects` to a path-list (`["**/*.vue", "**/*.css"]`) rather than dropping the optimisation entirely.
+
 ## Release Process
 
 - **release-please** (`.github/workflows/release.yml`) reads Conventional Commits since the last release tag and opens a PR that bumps versions and updates `CHANGELOG.md` per workspace.

--- a/.agents/plans/007-stability-roadmap.md
+++ b/.agents/plans/007-stability-roadmap.md
@@ -37,7 +37,7 @@ Each decision lands as a commit (often docs-only) that nails the contract. Items
 
 ## Track E — Bundle + browser story
 
-- [ ] **`sideEffects: false` audit** for `ilingo` and `@ilingo/vue`. Verify no top-level side effects so Vite/webpack tree-shaking works.
+- [x] **`sideEffects: false` audit** — extended to all four published packages (`ilingo`, `@ilingo/fs`, `@ilingo/vue`, `@ilingo/vuelidate`). Audit confirmed no top-level effects anywhere (no module-scope `console.*`, no globals, no prototype patching, no CSS imports, no bare effectful imports; the one Vue SFC has no `<style>` block). Policy + contract recorded in `.agents/conventions.md` under Build Output.
 - [ ] **Bundle-size budget** per package in CI (`size-limit` or `pkg-size`). Fail PRs that blow past it without justification.
 - [ ] **Cross-runtime smoke tests** for the `typeof process !== 'undefined'` guard around `NODE_ENV`. Cover Vite dev, Vite prod with DefinePlugin, raw browser ESM, Cloudflare Workers, Bun.
 

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -16,6 +16,7 @@
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "sideEffects": false,
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/ilingo/package.json
+++ b/packages/ilingo/package.json
@@ -16,6 +16,7 @@
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
+    "sideEffects": false,
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -6,6 +6,7 @@
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
+    "sideEffects": false,
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -6,6 +6,7 @@
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
+    "sideEffects": false,
     "exports": {
         "./package.json": "./package.json",
         ".": {


### PR DESCRIPTION
## Summary

First Track E item on the stability roadmap (#917). The four published packages — `ilingo`, `@ilingo/fs`, `@ilingo/vue`, `@ilingo/vuelidate` — now declare `"sideEffects": false`. The roadmap originally listed only `ilingo` + `@ilingo/vue`; extended to all four because the same audit applied to every package.

## What was checked

Each package's `src/` was audited for top-level side effects:

| Pattern | Status |
|---|---|
| Module-scope `console.*` | none |
| `globalThis.` / `window.` / `document.` at top level | none |
| Prototype mutation (`X.prototype.y = ...`) | none |
| CSS imports (`.css` / `.scss` / `.sass`) | none |
| Side-effect-only imports (`import 'pkg'`) | none |
| Vue SFC `<style>` blocks | none (only one SFC, `@ilingo/vue/src/component.vue`, has no style) |

Net diff is six lines — one `"sideEffects": false` per `package.json`, plus a policy paragraph in `.agents/conventions.md`.

## Why this matters

Without the field, bundlers conservatively assume every imported module *might* have side effects and skip dropping unused exports. A consumer that imports only `defineCatalog` from `ilingo` was previously pulling in `Ilingo`, `MemoryStore`, `LoaderStore`, `negotiateLocale`, and every utility. Now they get just `defineCatalog`.

The follow-up work (bundle-size budget in CI, second Track E item) will measure the impact concretely. This PR is the prerequisite.

## Future contract

Recorded under **Build Output → Tree-shaking** in `.agents/conventions.md`: keep packages side-effect-free by default. If a future change genuinely needs a side effect (CSS injection, polyfill registration), switch the field to a path-list (`["**/*.vue", "**/*.css"]`) rather than dropping the optimisation entirely.

## Test plan

- [x] `npm run build` — all five projects build green.
- [x] `npm run test:coverage` — all three test packages still pass their thresholds.
- [x] No runtime code touched; no API changes.
- [ ] CI green on PR.