### PR TITLE
build: size-limit budgets per package, enforced in CI

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -124,6 +124,26 @@ When adding new source files, keep this contract:
 - **OK**: function/class declarations, constants, JSON imports as values, lazy-imports inside function bodies (e.g. `FSStore`'s lazy `chokidar` import).
 - **Not OK without flipping the field**: top-level statements that run on import (registering globals, mutating prototypes, side-effect-only imports like `import 'some-polyfill'`, CSS imports). If you genuinely need any of these, change the package's `sideEffects` to a path-list (`["**/*.vue", "**/*.css"]`) rather than dropping the optimisation entirely.
 
+### Bundle size — `size-limit` budgets
+
+`.size-limit.json` at the repo root holds a budget per published-package entry — the full barrel for each, plus a couple of typical-slice imports for `ilingo` that validate tree-shaking. CI runs `npm run size` after the build; the job fails if any entry exceeds its limit. Current numbers (brotli, gzipped):
+
+| Entry | Budget | Current |
+|---|---|---|
+| `ilingo` — full barrel | 6 kB | 5.38 kB |
+| `ilingo` — `Ilingo + MemoryStore` | 5 kB | 3.33 kB |
+| `ilingo` — `defineCatalog` only | 1.3 kB | 1.18 kB |
+| `ilingo` — `negotiateLocale + parseAcceptLanguage` | 1.7 kB | 1.55 kB |
+| `@ilingo/fs` — full barrel | 4 kB | 3.00 kB |
+| `@ilingo/vue` — full barrel | 2 kB | 1.74 kB |
+| `@ilingo/vuelidate` — full barrel | 2.5 kB | 1.96 kB |
+
+`@ilingo/fs`'s entry ignores `node:*` modules and the optional `chokidar` peer (server-only package — those aren't consumer-bundled). `@ilingo/vue` and `@ilingo/vuelidate` ignore their declared peers (`vue`, `ilingo`, etc.).
+
+A consequence of `smob` and `pathtrace` not declaring `sideEffects: false` themselves: any single-symbol import from `ilingo` carries a ~1.2 kB floor from those upstream deps. That's why `defineCatalog` alone weighs 1.18 kB — it's not the function (it's an identity); it's the deps that come along. If we ever upstream `sideEffects: false` to those packages (or replace them with first-party code), the tree-shake floor drops further.
+
+Same ratchet rule as coverage thresholds: tighten budgets in the same PR that improves a number; never loosen one to keep CI green — investigate the regression first.
+
 ## Release Process
 
 - **release-please** (`.github/workflows/release.yml`) reads Conventional Commits since the last release tag and opens a PR that bumps versions and updates `CHANGELOG.md` per workspace.

--- a/.agents/plans/007-stability-roadmap.md
+++ b/.agents/plans/007-stability-roadmap.md
@@ -38,7 +38,7 @@ Each decision lands as a commit (often docs-only) that nails the contract. Items
 ## Track E — Bundle + browser story
 
 - [x] **`sideEffects: false` audit** — extended to all four published packages (`ilingo`, `@ilingo/fs`, `@ilingo/vue`, `@ilingo/vuelidate`). Audit confirmed no top-level effects anywhere (no module-scope `console.*`, no globals, no prototype patching, no CSS imports, no bare effectful imports; the one Vue SFC has no `<style>` block). Policy + contract recorded in `.agents/conventions.md` under Build Output.
-- [ ] **Bundle-size budget** per package in CI (`size-limit` or `pkg-size`). Fail PRs that blow past it without justification.
+- [x] **Bundle-size budget** per package in CI. `size-limit` with the `preset-small-lib` (esbuild + brotli) is configured at the repo root in `.size-limit.json`; CI runs `npm run size` after build and fails the job on budget violations. Seven entries: a full barrel per package plus three tree-shake-validation imports on `ilingo` (`Ilingo+MemoryStore`, `defineCatalog` only, `negotiateLocale+parseAcceptLanguage`). Headroom: ~10–15% over current numbers. Tree-shake floor is bounded at ~1.2 kB by `smob`/`pathtrace` not declaring `sideEffects:false` themselves — noted in `.agents/conventions.md` as a future drop-down opportunity.
 - [ ] **Cross-runtime smoke tests** for the `typeof process !== 'undefined'` guard around `NODE_ENV`. Cover Vite dev, Vite prod with DefinePlugin, raw browser ESM, Cloudflare Workers, Bun.
 
 ## Track F — Ecosystem decisions (in / out / deferred)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,15 @@ jobs:
                     node-version: ${{ matrix.node-version }}
             -   uses: ./.github/actions/build
             -   run: npm run test:coverage
+
+    size:
+        name: Bundle size
+        needs: [build]
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v6
+            -   uses: ./.github/actions/install
+                with:
+                    node-version: ${{ env.PRIMARY_NODE_VERSION }}
+            -   uses: ./.github/actions/build
+            -   run: npm run size

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,57 @@
+[
+    {
+        "name": "ilingo — full barrel",
+        "path": "packages/ilingo/dist/index.mjs",
+        "limit": "6 KB"
+    },
+    {
+        "name": "ilingo — Ilingo + MemoryStore (typical minimum)",
+        "path": "packages/ilingo/dist/index.mjs",
+        "import": "{ Ilingo, MemoryStore }",
+        "limit": "5 KB"
+    },
+    {
+        "name": "ilingo — defineCatalog only (tree-shake floor)",
+        "path": "packages/ilingo/dist/index.mjs",
+        "import": "{ defineCatalog }",
+        "limit": "1.3 KB"
+    },
+    {
+        "name": "ilingo — negotiateLocale + parseAcceptLanguage",
+        "path": "packages/ilingo/dist/index.mjs",
+        "import": "{ negotiateLocale, parseAcceptLanguage }",
+        "limit": "1.7 KB"
+    },
+    {
+        "name": "@ilingo/fs — full barrel (node externals)",
+        "path": "packages/fs/dist/index.mjs",
+        "ignore": [
+            "node:fs",
+            "node:fs/promises",
+            "node:path",
+            "node:process",
+            "chokidar",
+            "ilingo",
+            "locter"
+        ],
+        "limit": "4 KB"
+    },
+    {
+        "name": "@ilingo/vue — full barrel",
+        "path": "packages/vue/dist/index.mjs",
+        "ignore": ["vue", "ilingo", "@vueuse/core"],
+        "limit": "2 KB"
+    },
+    {
+        "name": "@ilingo/vuelidate — full barrel",
+        "path": "packages/vuelidate/dist/index.mjs",
+        "ignore": [
+            "vue",
+            "ilingo",
+            "@ilingo/vue",
+            "@vueuse/core",
+            "@vuelidate/core"
+        ],
+        "limit": "2.5 KB"
+    }
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "./docs"
             ],
             "devDependencies": {
+                "@size-limit/preset-small-lib": "^12.1.0",
                 "@tada5hi/commitlint-config": "^1.3.1",
                 "@tada5hi/eslint-config": "^2.3.0",
                 "@tada5hi/tsconfig": "^0.7.2",
@@ -24,6 +25,7 @@
                 "husky": "^9.1.7",
                 "nx": "^22.3.3",
                 "rimraf": "^6.1.2",
+                "size-limit": "^12.1.0",
                 "tsdown": "^0.22.0",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.59.2",
@@ -2749,6 +2751,554 @@
                 "url": "https://ko-fi.com/dangreen"
             }
         },
+        "node_modules/@size-limit/esbuild": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-12.1.0.tgz",
+            "integrity": "sha512-Um6MVrX+05kIxI4+zk0ZByG9dA/Th1f+sfGc571D95BnCPc90/pl2+2OdsQuOyoWEbeAMqfcTKo0v07i+E65Vw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.28.0",
+                "nanoid": "^5.1.7"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "size-limit": "12.1.0"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/android-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/esbuild": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
+            }
+        },
+        "node_modules/@size-limit/esbuild/node_modules/nanoid": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+            "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^18 || >=20"
+            }
+        },
+        "node_modules/@size-limit/file": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+            "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "size-limit": "12.1.0"
+            }
+        },
+        "node_modules/@size-limit/preset-small-lib": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-12.1.0.tgz",
+            "integrity": "sha512-TVVQ/iuHbaGtHJrjur5s4XKYEyGk0nIwUAqhuzhKPbTyV9nYOH/laDelQ4vg3cGmm8sayRx998wxEdnwM/Yewg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@size-limit/esbuild": "12.1.0",
+                "@size-limit/file": "12.1.0",
+                "size-limit": "12.1.0"
+            },
+            "peerDependencies": {
+                "size-limit": "12.1.0"
+            }
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4321,6 +4871,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/bytes-iec": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+            "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/cac": {
@@ -7112,6 +7672,19 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/lilconfig": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
+            }
+        },
         "node_modules/lines-and-columns": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
@@ -7569,6 +8142,16 @@
             },
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/nanospinner": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+            "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.1.1"
             }
         },
         "node_modules/natural-compare": {
@@ -8702,6 +9285,34 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/size-limit": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+            "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes-iec": "^3.1.1",
+                "lilconfig": "^3.1.3",
+                "nanospinner": "^1.2.2",
+                "picocolors": "^1.1.1",
+                "tinyglobby": "^0.2.16"
+            },
+            "bin": {
+                "size-limit": "bin.js"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "jiti": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/smob": {
             "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "node": ">=22.0.0"
     },
     "devDependencies": {
+        "@size-limit/preset-small-lib": "^12.1.0",
         "@tada5hi/commitlint-config": "^1.3.1",
         "@tada5hi/eslint-config": "^2.3.0",
         "@tada5hi/tsconfig": "^0.7.2",
@@ -49,6 +50,7 @@
         "husky": "^9.1.7",
         "nx": "^22.3.3",
         "rimraf": "^6.1.2",
+        "size-limit": "^12.1.0",
         "tsdown": "^0.22.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
@@ -60,6 +62,7 @@
         "build": "npx nx run-many -t build",
         "test": "npx nx run-many -t test",
         "test:coverage": "npx nx run-many -t test:coverage",
+        "size": "size-limit",
         "lint": "eslint",
         "lint:fix": "npm run lint -- --fix",
         "prepare": "husky"


### PR DESCRIPTION
## Summary

Second Track E item on the stability roadmap (#917). `size-limit` with `preset-small-lib` (esbuild + brotli) sits at the repo root; CI runs `npm run size` after build and fails the job on budget violations. Same gate shape as the coverage thresholds from #929.

### Budgets

| Entry | Budget | Current |
|---|--:|--:|
| `ilingo` — full barrel | 6 kB | 5.38 kB |
| `ilingo` — `Ilingo + MemoryStore` (typical minimum) | 5 kB | 3.33 kB |
| `ilingo` — `defineCatalog` only (tree-shake floor) | 1.3 kB | 1.18 kB |
| `ilingo` — `negotiateLocale + parseAcceptLanguage` | 1.7 kB | 1.55 kB |
| `@ilingo/fs` — full barrel | 4 kB | 3.00 kB |
| `@ilingo/vue` — full barrel | 2 kB | 1.74 kB |
| `@ilingo/vuelidate` — full barrel | 2.5 kB | 1.96 kB |

The three single-export `ilingo` entries are **tree-shake gates**, not just size budgets. They confirm that `sideEffects: false` (PR #933) actually lets esbuild drop unused exports.

### Surprise finding

The floor for any single-symbol import from `ilingo` is **~1.2 kB**, not the 5 lines the function itself takes up. Cause: `smob` and `pathtrace` (the only two runtime deps) don't declare `sideEffects: false` themselves, so esbuild conservatively keeps their top-level imports regardless of which named export you grab.

Now visible in CI as the `defineCatalog only` floor and called out in `.agents/conventions.md` as a future drop-down opportunity — upstreaming `sideEffects: false` to those packages (or replacing them with first-party code) would let any single-symbol import drop below 200 B.

### Configuration notes

- `@ilingo/fs`'s entry ignores `node:*` modules + the optional `chokidar` peer + `ilingo` + `locter` — server-only package, none of those are consumer-bundled.
- `@ilingo/vue` and `@ilingo/vuelidate` ignore declared peer deps (`vue`, `ilingo`, `@vueuse/core`, `@vuelidate/core`).
- Same ratchet rule as coverage: tighten budgets in the same PR that improves a number; never loosen one to keep CI green — investigate the regression first.

### Wiring

- `.size-limit.json` at the repo root with the seven entries.
- Root `package.json` gains `"size": "size-limit"`.
- New `size` job in `.github/workflows/main.yml` (parallels the `tests` job, depends on `build`).
- `size-limit` + `@size-limit/preset-small-lib` added as workspace devDeps.

## Test plan

- [x] `npm run size` from repo root — all seven entries pass.
- [x] `npm run build` + `npm run test:coverage` still green.
- [x] Manually verified `@ilingo/fs` builds successfully with `node:*` externals ignored (it imports `node:fs/promises` and the optional `chokidar` peer).
- [ ] CI `size` job green on PR.

Plan ticked. Track E status after this lands: 2 of 3. Remaining item is cross-runtime smoke tests (Vite dev / prod, raw browser ESM, Cloudflare Workers, Bun).