### PR TITLE
chore: improve package discoverability (descriptions, keywords, badges)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # ilingo 📚
 
-A lightweight library for translation and internationalization.
+[![npm version](https://img.shields.io/npm/v/ilingo.svg)](https://www.npmjs.com/package/ilingo)
+[![npm downloads](https://img.shields.io/npm/dm/ilingo.svg)](https://www.npmjs.com/package/ilingo)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/ilingo)](https://bundlephobia.com/package/ilingo)
+[![Master Workflow](https://github.com/tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/tada5hi/ilingo/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/tada5hi/ilingo/branch/master/graph/badge.svg?token=4KNSG8L13V)](https://codecov.io/gh/tada5hi/ilingo)
+
+A lightweight, framework-agnostic translation and internationalization (i18n) library for TypeScript — pluggable stores, BCP-47 fallback, ICU-lite plurals, and Intl-native formatters.
 
 **Table of Contents**
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "type": "module",
-    "description": "This is a lightweight library for translation.",
+    "description": "A lightweight, framework-agnostic translation and internationalization (i18n) library for TypeScript — pluggable stores, BCP-47 fallback, ICU-lite plurals, Intl formatters.",
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",
@@ -19,15 +19,24 @@
     },
     "keywords": [
         "i18n",
-        "language",
+        "internationalization",
+        "localization",
+        "l10n",
         "translate",
         "translation",
-        "bilingual",
-        "internationalization",
         "locale",
         "locales",
+        "intl",
+        "pluralization",
+        "bcp47",
+        "typescript",
+        "lightweight",
+        "tree-shakeable",
+        "ssr",
+        "edge",
         "server-side",
-        "client-side"
+        "client-side",
+        "i18next-alternative"
     ],
     "license": "MIT",
     "engines": {

--- a/packages/fs/README.md
+++ b/packages/fs/README.md
@@ -1,6 +1,8 @@
 # @ilingo/fs 🗃️
 
-[![npm version](https://badge.fury.io/js/@ilingo%2Ffs.svg)](https://badge.fury.io/js/@ilingo%2Ffs)
+[![npm version](https://img.shields.io/npm/v/@ilingo/fs.svg)](https://www.npmjs.com/package/@ilingo/fs)
+[![npm downloads](https://img.shields.io/npm/dm/@ilingo/fs.svg)](https://www.npmjs.com/package/@ilingo/fs)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/@ilingo/fs)](https://bundlephobia.com/package/@ilingo/fs)
 [![main](https://github.com/Tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/ilingo/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/tada5hi/ilingo/branch/master/graph/badge.svg?token=CLIA667K6V)](https://codecov.io/gh/tada5hi/ilingo)
 [![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/ilingo/badge.svg)](https://snyk.io/test/github/Tada5hi/ilingo)

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -2,7 +2,7 @@
     "name": "@ilingo/fs",
     "type": "module",
     "version": "6.0.0",
-    "description": "This is a lightweight library for translation.",
+    "description": "File-system store adapter for ilingo — lazy-loads locale catalogs from disk and persists translations as JSON.",
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",
@@ -47,15 +47,17 @@
     },
     "keywords": [
         "i18n",
-        "language",
-        "translate",
-        "translation",
-        "bilingual",
         "internationalization",
+        "translation",
         "locale",
-        "locales",
+        "ilingo",
+        "filesystem",
+        "fs",
+        "file-loader",
+        "node",
         "server-side",
-        "client-side"
+        "typescript",
+        "lightweight"
     ],
     "license": "MIT",
     "dependencies": {

--- a/packages/ilingo/README.md
+++ b/packages/ilingo/README.md
@@ -1,10 +1,12 @@
 # ilingo 💬
 
-[![npm version](https://badge.fury.io/js/ilingo.svg)](https://badge.fury.io/js/ilingo)
+[![npm version](https://img.shields.io/npm/v/ilingo.svg)](https://www.npmjs.com/package/ilingo)
+[![npm downloads](https://img.shields.io/npm/dm/ilingo.svg)](https://www.npmjs.com/package/ilingo)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/ilingo)](https://bundlephobia.com/package/ilingo)
 [![codecov](https://codecov.io/gh/tada5hi/ilingo/branch/master/graph/badge.svg?token=4KNSG8L13V)](https://codecov.io/gh/tada5hi/ilingo)
 [![Master Workflow](https://github.com/tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/tada5hi/ilingo)
 [![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/ilingo/badge.svg?targetFile=package.json)](https://snyk.io/test/github/Tada5hi/ilingo?targetFile=package.json)
-[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
 Ilingo is a lightweight library for translation and internationalization. The core's only runtime dependencies are [`pathtrace`](https://www.npmjs.com/package/pathtrace) and [`smob`](https://www.npmjs.com/package/smob); on common workloads it runs **1.6× – 2.3× faster than `i18next`** ([benchmarks](https://ilingo.tada5hi.net/performance)).
 

--- a/packages/ilingo/package.json
+++ b/packages/ilingo/package.json
@@ -2,7 +2,7 @@
     "name": "ilingo",
     "type": "module",
     "version": "6.0.0",
-    "description": "This is a lightweight library for translation.",
+    "description": "A lightweight, framework-agnostic translation and internationalization (i18n) library for TypeScript — pluggable stores, BCP-47 fallback, ICU-lite plurals, Intl formatters.",
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",
@@ -43,15 +43,24 @@
     },
     "keywords": [
         "i18n",
-        "language",
+        "internationalization",
+        "localization",
+        "l10n",
         "translate",
         "translation",
-        "bilingual",
-        "internationalization",
         "locale",
         "locales",
+        "intl",
+        "pluralization",
+        "bcp47",
+        "typescript",
+        "lightweight",
+        "tree-shakeable",
+        "ssr",
+        "edge",
         "server-side",
-        "client-side"
+        "client-side",
+        "i18next-alternative"
     ],
     "license": "MIT",
     "dependencies": {

--- a/packages/validup-vue/README.md
+++ b/packages/validup-vue/README.md
@@ -1,5 +1,11 @@
 # @ilingo/validup-vue
 
+[![npm version](https://img.shields.io/npm/v/@ilingo/validup-vue.svg)](https://www.npmjs.com/package/@ilingo/validup-vue)
+[![npm downloads](https://img.shields.io/npm/dm/@ilingo/validup-vue.svg)](https://www.npmjs.com/package/@ilingo/validup-vue)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/@ilingo/validup-vue)](https://bundlephobia.com/package/@ilingo/validup-vue)
+[![main](https://github.com/tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/tada5hi/ilingo/actions/workflows/main.yml)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
 Vue 3 plugin for [`@ilingo/validup`](../validup) — the install hook, five composables, the `<IValidup>` / `<IValidupT>` / `<IFieldValidation>` renderless components, and the `FieldTranslations` / `GroupTranslations` / `FieldValidation` aliases.
 
 Sibling of [`@ilingo/vue`](../vue) and [`@ilingo/vuelidate`](../vuelidate); mirrors the `validup` → `@validup/vue` package split so the framework-agnostic validation-message surface (`@ilingo/validup`) stays free of Vue.

--- a/packages/validup-vue/package.json
+++ b/packages/validup-vue/package.json
@@ -34,8 +34,12 @@
         "validup",
         "validation",
         "i18n",
+        "internationalization",
         "translation",
-        "vue"
+        "locale",
+        "vue",
+        "vue3",
+        "typescript"
     ],
     "author": {
         "name": "Peter Placzek",

--- a/packages/validup/README.md
+++ b/packages/validup/README.md
@@ -1,5 +1,11 @@
 # @ilingo/validup
 
+[![npm version](https://img.shields.io/npm/v/@ilingo/validup.svg)](https://www.npmjs.com/package/@ilingo/validup)
+[![npm downloads](https://img.shields.io/npm/dm/@ilingo/validup.svg)](https://www.npmjs.com/package/@ilingo/validup)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/@ilingo/validup)](https://bundlephobia.com/package/@ilingo/validup)
+[![main](https://github.com/tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/tada5hi/ilingo/actions/workflows/main.yml)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+
 Translate [validup](https://www.npmjs.com/package/validup) `Issue`s through [ilingo](https://www.npmjs.com/package/ilingo) — default EN / DE / FR / ES catalogs for the built-in `IssueCode`s, a pre-seeded `Store`, and pure `translateIssue` / `translateIssues` helpers.
 
 **No Vue dependency.** Embeddable in any runtime: Node SSR, edge workers, queue handlers, CLI tools. Vue 3 users add [`@ilingo/validup-vue`](../validup-vue) on top for composables, the renderless component, and the install plugin.

--- a/packages/validup/package.json
+++ b/packages/validup/package.json
@@ -42,7 +42,10 @@
         "validup",
         "validation",
         "i18n",
-        "translation"
+        "internationalization",
+        "translation",
+        "locale",
+        "typescript"
     ],
     "author": {
         "name": "Peter Placzek",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,6 +1,8 @@
 # @ilingo/vue 🖌️
 
-[![npm version](https://badge.fury.io/js/@ilingo%2Fvue.svg)](https://badge.fury.io/js/@ilingo%2Fvue)
+[![npm version](https://img.shields.io/npm/v/@ilingo/vue.svg)](https://www.npmjs.com/package/@ilingo/vue)
+[![npm downloads](https://img.shields.io/npm/dm/@ilingo/vue.svg)](https://www.npmjs.com/package/@ilingo/vue)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/@ilingo/vue)](https://bundlephobia.com/package/@ilingo/vue)
 [![main](https://github.com/Tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/ilingo/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/tada5hi/ilingo/branch/master/graph/badge.svg?token=CLIA667K6V)](https://codecov.io/gh/tada5hi/ilingo)
 [![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/ilingo/badge.svg)](https://snyk.io/test/github/Tada5hi/ilingo)

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,7 @@
     "name": "@ilingo/vue",
     "type": "module",
     "version": "6.0.0",
-    "description": "This package contains the vue package of ilingo.",
+    "description": "Vue 3 integration for ilingo — provide/inject, reactive locale, the <ITranslate> component, a v-t directive, and the useTranslation composable.",
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -36,7 +36,21 @@
     "engines": {
         "node": ">=22.0.0"
     },
-    "keywords": [],
+    "keywords": [
+        "i18n",
+        "internationalization",
+        "translation",
+        "locale",
+        "ilingo",
+        "vue",
+        "vue3",
+        "vue-i18n-alternative",
+        "composables",
+        "intl",
+        "typescript",
+        "lightweight",
+        "ssr"
+    ],
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",

--- a/packages/vuelidate/README.md
+++ b/packages/vuelidate/README.md
@@ -1,6 +1,8 @@
 # @ilingo/vuelidate 🎉
 
-[![npm version](https://badge.fury.io/js/@ilingo%2Fvuelidate.svg)](https://badge.fury.io/js/@ilingo%2Fvuelidate)
+[![npm version](https://img.shields.io/npm/v/@ilingo/vuelidate.svg)](https://www.npmjs.com/package/@ilingo/vuelidate)
+[![npm downloads](https://img.shields.io/npm/dm/@ilingo/vuelidate.svg)](https://www.npmjs.com/package/@ilingo/vuelidate)
+[![minzipped size](https://img.shields.io/bundlephobia/minzip/@ilingo/vuelidate)](https://bundlephobia.com/package/@ilingo/vuelidate)
 [![main](https://github.com/Tada5hi/ilingo/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/ilingo/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/tada5hi/ilingo/branch/master/graph/badge.svg?token=CLIA667K6V)](https://codecov.io/gh/tada5hi/ilingo)
 [![Known Vulnerabilities](https://snyk.io/test/github/Tada5hi/ilingo/badge.svg)](https://snyk.io/test/github/Tada5hi/ilingo)

--- a/packages/vuelidate/package.json
+++ b/packages/vuelidate/package.json
@@ -2,7 +2,7 @@
     "name": "@ilingo/vuelidate",
     "type": "module",
     "version": "7.0.0",
-    "description": "This package contains a vuelidate plugin for ilingo.",
+    "description": "Vuelidate message adapter for ilingo — drop-in localized validator messages (EN/DE/FR/ES) for Vue 3 forms.",
     "main": "./dist/index.mjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
@@ -48,7 +48,19 @@
     "engines": {
         "node": ">=22.0.0"
     },
-    "keywords": [],
+    "keywords": [
+        "i18n",
+        "internationalization",
+        "translation",
+        "locale",
+        "ilingo",
+        "vuelidate",
+        "vue",
+        "vue3",
+        "validation",
+        "validation-messages",
+        "typescript"
+    ],
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",


### PR DESCRIPTION
## Summary

Phase 0 foundation for package promotion — makes the npm/GitHub surface reflect what ilingo actually is, so it surfaces for the searches its target users run, and gives the landing pages a live demo.

### `chore:` descriptions + keywords (`0c41f4a`)
- Replace the generic *"This is a lightweight library for translation."* across the root and all six packages with tailored, differentiator-led descriptions.
- Expand npm `keywords` (`intl`, `pluralization`, `bcp47`, `tree-shakeable`, `ssr`, `edge`, `vue3`, `i18next-alternative`, …); `@ilingo/vue` adds `vue-i18n-alternative`, `@ilingo/fs` adds `filesystem`/`fs`/`node`.

### `docs:` README badges (`edf93f6`)
- Add **npm-downloads** + **bundlephobia minzipped-size** badges to the root and all six package READMEs. The size badge is the core *lightweight* selling point.
- Give `@ilingo/validup` and `@ilingo/validup-vue` a badge row (they had none).
- Replace `ilingo`'s stale `semantic-release` badge with **Conventional Commits** to match the rest of the repo.

### `docs:` live demo GIF (`4cd9e85`)
- Embed a looping demo of the Hero playground — locale switch → **BCP-47 fallback chain** → plural → interpolation → `Intl` currency formatting — in the root + core-package READMEs. Asset in `docs/src/public/` so it also ships with the docs site (612×576, ~370 kB).

### Also (not in this PR, applied directly)
- GitHub repo **topics** expanded to 19 (added `internationalization`, `intl`, `vue`, `bcp47`, `pluralization`, `lightweight`, `tree-shakeable`, `ssr`, `edge`, `i18next-alternative`; pruned `language`/`translate`/`bilingual`).

## Notes
- All six packages verified published; bundlephobia confirmed `ilingo` ≈ 6 kB gzip. bundlephobia excludes peer deps, so `@ilingo/vue`'s badge shows its own ~1.7 kB, not Vue's.
- A couple of scoped-package size badges may show "pending" until bundlephobia builds them on first view; they self-heal.
- The core README's GIF uses an absolute raw-GitHub URL (npm needs absolute); the root README uses a repo-relative path.